### PR TITLE
list_disk_snapshots.py: look for template snapshots in the chain

### DIFF
--- a/examples/list_disk_snapshots.py
+++ b/examples/list_disk_snapshots.py
@@ -45,28 +45,13 @@ with closing(connection):
     # Find the disk.
     disks_service = connection.system_service().disks_service()
     disk_service = disks_service.disk_service(args.disk_id)
-
-    try:
-        disk = disk_service.get()
-    except sdk.NotFoundError:
-        raise RuntimeError("No such disk: {}".format(args.disk_id)) from None
-
-    # Find the storage domain service.
-    sd_id = disk.storage_domains[0].id
-    sds_service = connection.system_service().storage_domains_service()
-    sd_service = sds_service.storage_domain_service(sd_id)
-
-    # Find the disk snapshots using the disk snapshots service.
-    # TODO: Use disk's snapshots service to get filter the snapshot on the
-    # server side.
-    disk_snapshots_service = sd_service.disk_snapshots_service()
+    disk_snapshots_service = disk_service.disk_snapshots_service()
 
     # Create mapping from snapshot parent to snapshot, used to reconstruct the
     # snapshot chain.
     snapshots = {}
-    for s in disk_snapshots_service.list(include_active=True):
-        if s.disk.id != disk.id:
-            continue
+
+    for s in disk_snapshots_service.list(include_active=True, include_template=True):
         parent = s.parent.id if s.parent else None
         child = {
             "actual_size": s.actual_size,


### PR DESCRIPTION
When a VM is created from template with Thin Storage Allocation,
the parent of one of the snapshots will be the template image, thus
not returned in the result set for the list disksnapshots request.
In this case, when requesting snapshots of a disk created this way -
this script returns an error.

To handle this, the patch:
- Calls for snapshots list with the include_template flag
- After the main loop detects snapshots with disk.id == args.disk_id
another loop goes through the remaining snapshots, looking for ones
that are parents of the already found snapshots, thus completing
the snapshot chain.

Bug-Url: https://bugzilla.redhat.com/1900597