### PR TITLE
Automation: disable python38 build

### DIFF
--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -17,16 +17,16 @@ rpmbuild \
     -D "_sourcedir $PWD/" \
     -D "_topmdir $PWD/rpmbuild" \
     -bs ./python-ovirt-engine-sdk4.spec
-<< ////
-if [[ "$(rpm --eval "%dist")" == ".el8" ]]; then
+# Below lines are not needed as Python 3.8 is not used at the moment
+#if [[ "$(rpm --eval "%dist")" == ".el8" ]]; then
 # create the src.rpm
-rpmbuild \
-    -D "_srcrpmdir $PWD/output" \
-    -D "_sourcedir $PWD/" \
-    -D "_topmdir $PWD/rpmbuild" \
-    -bs ./python38-ovirt-engine-sdk4.spec
-fi
-////
+#rpmbuild \
+#    -D "_srcrpmdir $PWD/output" \
+#    -D "_sourcedir $PWD/" \
+#    -D "_topmdir $PWD/rpmbuild" \
+#    -bs ./python38-ovirt-engine-sdk4.spec
+#fi
+
 
 # install any build requirements
 dnf builddep output/*src.rpm

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -17,7 +17,7 @@ rpmbuild \
     -D "_sourcedir $PWD/" \
     -D "_topmdir $PWD/rpmbuild" \
     -bs ./python-ovirt-engine-sdk4.spec
-
+<< ////
 if [[ "$(rpm --eval "%dist")" == ".el8" ]]; then
 # create the src.rpm
 rpmbuild \
@@ -26,6 +26,7 @@ rpmbuild \
     -D "_topmdir $PWD/rpmbuild" \
     -bs ./python38-ovirt-engine-sdk4.spec
 fi
+////
 
 # install any build requirements
 dnf builddep output/*src.rpm

--- a/build.sh
+++ b/build.sh
@@ -22,12 +22,14 @@ dist() {
    -e "s|@PACKAGE_NAME@|$PACKAGE_NAME|g" \
    -e "s|@PACKAGE_VERSION@|$PACKAGE_VERSION|g" \
    < python-ovirt-engine-sdk4.spec.in > python-ovirt-engine-sdk4.spec
+<< ////
   sed \
    -e "s|@RPM_VERSION@|$RPM_VERSION|g" \
    -e "s|@RPM_RELEASE@|$RPM_RELEASE|g" \
    -e "s|@PACKAGE_NAME@|$PACKAGE_NAME|g" \
    -e "s|@PACKAGE_VERSION@|$PACKAGE_VERSION|g" \
    < python38-ovirt-engine-sdk4.spec.in > python38-ovirt-engine-sdk4.spec
+////
 
   find ./* -not -name '*.spec' -not -name 'mocker-*' -not -name 'ci_build_summary.html' -type f | tar --files-from /proc/self/fd/0 -czf "$TARBALL" python-ovirt-engine-sdk4.spec
   echo "tar archive '$TARBALL' created."

--- a/build.sh
+++ b/build.sh
@@ -22,14 +22,13 @@ dist() {
    -e "s|@PACKAGE_NAME@|$PACKAGE_NAME|g" \
    -e "s|@PACKAGE_VERSION@|$PACKAGE_VERSION|g" \
    < python-ovirt-engine-sdk4.spec.in > python-ovirt-engine-sdk4.spec
-<< ////
-  sed \
-   -e "s|@RPM_VERSION@|$RPM_VERSION|g" \
-   -e "s|@RPM_RELEASE@|$RPM_RELEASE|g" \
-   -e "s|@PACKAGE_NAME@|$PACKAGE_NAME|g" \
-   -e "s|@PACKAGE_VERSION@|$PACKAGE_VERSION|g" \
-   < python38-ovirt-engine-sdk4.spec.in > python38-ovirt-engine-sdk4.spec
-////
+# Below lines are not needed as Python 3.8 is not used at the moment
+#  sed \
+#   -e "s|@RPM_VERSION@|$RPM_VERSION|g" \
+#   -e "s|@RPM_RELEASE@|$RPM_RELEASE|g" \
+#   -e "s|@PACKAGE_NAME@|$PACKAGE_NAME|g" \
+#   -e "s|@PACKAGE_VERSION@|$PACKAGE_VERSION|g" \
+#   < python38-ovirt-engine-sdk4.spec.in > python38-ovirt-engine-sdk4.spec
 
   find ./* -not -name '*.spec' -not -name 'mocker-*' -not -name 'ci_build_summary.html' -type f | tar --files-from /proc/self/fd/0 -czf "$TARBALL" python-ovirt-engine-sdk4.spec
   echo "tar archive '$TARBALL' created."


### PR DESCRIPTION
From now we are using pypi version of the sdk, python38 is no longer needed.