### PR TITLE
backup_vm: Fix --backup-uuid argument

### DIFF
--- a/examples/backup_vm.py
+++ b/examples/backup_vm.py
@@ -270,7 +270,7 @@ def add_start_backup_args(parser):
         help="UUID of the VM to backup.")
 
     parser.add_argument(
-        "--backup_uuid",
+        "--backup-uuid",
         help="UUID of the created VM backup.")
 
     parser.add_argument(


### PR DESCRIPTION
In commit a4a0339f49cdc2bb3c6163f1d79579888f414fdd

    Add backup UUID for backup vm (#28)

the argument was added as --backup_uuid to "start" "full" and
"incremental" sub commands. This is not consistent with --backup-uuid
argument of the "download" sub command and other arguments (--disk-uuid,
--backup-dir).

Staring backup with --backup--uuid argument fails with:

$ ./backup_vm.py -c engine-dev start --backup-uuid 1-2-3-4
usage: backup_vm.py [-h] -c CONFIG [--debug] [--logfile LOGFILE]
                    {full,incremental,start,download,stop} ...
backup_vm.py: error: unrecognized arguments: --backup-uuid