### PR TITLE
upload_disk: Show how to set inactivity timeout

### DIFF
--- a/examples/upload_disk.py
+++ b/examples/upload_disk.py
@@ -104,6 +104,13 @@ def parse_args():
              .format(client.BUFFER_SIZE))
 
     parser.add_argument(
+        "--inactivity-timeout",
+        type=int,
+        help="Number of seconds to wait before aborting an inactive "
+             "transfer. May be needed when uploading an image from "
+             "a very slow remote file system.")
+
+    parser.add_argument(
         "--timeout-policy",
         choices=('legacy', 'pause', 'cancel'),
         default='cancel',
@@ -258,8 +265,12 @@ with closing(connection):
     # oVirt hypervisor in the same data center.
     host = imagetransfer.find_host(connection, args.sd_name)
 
-    transfer = imagetransfer.create_transfer(connection, disk,
-        types.ImageTransferDirection.UPLOAD, host=host,
+    transfer = imagetransfer.create_transfer(
+        connection,
+        disk,
+        types.ImageTransferDirection.UPLOAD,
+        host=host,
+        inactivity_timeout=args.inactivity_timeout,
         timeout_policy=types.ImageTransferTimeoutPolicy(args.timeout_policy))
     try:
         # oVirt started an image transfer for uploading the image data into the


### PR DESCRIPTION
Add --inactivity-timeout command line option. I don't think that any
user will need this, but it very useful for testing that engine pass the
right value to ovirt-imageio.

For more info on why inactivity timeout is needed see:
https://github.com/oVirt/ovirt-imageio/issues/14