### PR TITLE
Fix issue when pushing generated documentation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,7 @@ on:
 env:
   LD_LIBRARY_PATH: /usr/local/opt/curl/lib:$LD_LIBRARY_PATH
   PYCURL_SSL_LIBRARY: openssl
+  GEN_DOC_DIR: html
 
 jobs:
   build:
@@ -29,7 +30,6 @@ jobs:
 
     env:
       ARTIFACTS_DIR: exported-artifacts
-      GEN_DOC_DIR: html
 
     container:
       image: quay.io/centos/centos:${{ matrix.container-name }}


### PR DESCRIPTION
Fix issue where environment variable with the generated
documentation directory was not propagated to publish-doc job.

Signed-off-by: Martin Perina <mperina@redhat.com>
