### PR TITLE
automation: fix docs paths

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,8 +101,7 @@ jobs:
         if: ${{ matrix.shortcut == 'cs9' }}
         uses: actions/checkout@v2
         with:
-          repository: '${{ secrets.TARGET_REPO }}'
-          ssh-key: '${{ secrets.DEPLOY_KEY }}'
+          repository: 'ovirt/ovirt-engine-sdk'
           path: ovirt-engine-sdk
           ref: 'gh-pages'
 
@@ -168,8 +167,6 @@ jobs:
             echo "FOLDER=${value:0:3}" >> $GITHUB_ENV;
           fi
 
-      - name: Get path
-        run: ls -l
       - name: Move created documentation to gh-pages
         run: |
           mkdir -p ./ovirt-engine-sdk/${{env.FOLDER}}/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -101,7 +101,6 @@ jobs:
         if: ${{ matrix.shortcut == 'cs9' }}
         uses: actions/checkout@v2
         with:
-          repository: 'ovirt/ovirt-engine-sdk'
           path: ovirt-engine-sdk
           ref: 'gh-pages'
 
@@ -146,8 +145,6 @@ jobs:
       - name: Checkout target repository
         uses: actions/checkout@v2
         with:
-          repository: '${{ secrets.TARGET_REPO }}'
-          ssh-key: '${{ secrets.DEPLOY_KEY }}'
           path: ovirt-engine-sdk
           ref: 'gh-pages'
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,6 +98,7 @@ jobs:
         run: pip3 install . -U
 
       - name: Checkout target repository
+        if: ${{ matrix.shortcut == 'cs9' }}
         uses: actions/checkout@v2
         with:
           repository: '${{ secrets.TARGET_REPO }}'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -97,6 +97,14 @@ jobs:
         if: ${{ matrix.shortcut == 'cs9' }}
         run: pip3 install . -U
 
+      - name: Checkout target repository
+        uses: actions/checkout@v2
+        with:
+          repository: '${{ secrets.TARGET_REPO }}'
+          ssh-key: '${{ secrets.DEPLOY_KEY }}'
+          path: ovirt-engine-sdk
+          ref: 'gh-pages'
+
       - name: Create python documentation
         if: ${{ matrix.shortcut == 'cs9' }}
         run: pdoc -t ovirt-engine-sdk -o ${GEN_DOC_DIR} ovirtsdk4


### PR DESCRIPTION
issue was that we use a custom pdoc template https://github.com/oVirt/ovirt-engine-sdk/blob/gh-pages/module.html.jinja2
When the docs were being created it was missing the template.
(Can't remove the https://github.com/oVirt/python-ovirt-engine-sdk4/blob/main/.github/workflows/build.yaml#L138-L144 because it is in another github "task" and it did not share .git folder from the previous task so we need to refresh the .git folder)