### PR TITLE
automation: change secrets to deploy key

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -147,7 +147,7 @@ jobs:
         with:
           path: ovirt-engine-sdk
           ref: 'gh-pages'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          ssh-key: '${{ secrets.DEPLOY_KEY }}'
 
       - name: Set FOLDER variable according to pushed branch
         run: |


### PR DESCRIPTION
We can't use the GITHUB_TOKEN because it is limited by permissions. 