### PR TITLE
remove centos9 from build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,9 +22,6 @@ jobs:
           - name: centos-stream-8
             shortcut: cs8
             container-name: stream8
-          - name: centos-stream-9
-            shortcut: cs9
-            container-name: stream9
 
     name: ${{ matrix.name }}
 
@@ -35,11 +32,6 @@ jobs:
       image: quay.io/centos/centos:${{ matrix.container-name }}
 
     steps:
-      - name: Install DNF core plugins
-        if: ${{ matrix.shortcut == 'cs9' }}
-        run: |
-          # DNF core plugins are installed in the official CS9 container image
-          dnf install -y dnf-plugins-core
 
       - name: Prepare build environment
         run: |
@@ -90,26 +82,21 @@ jobs:
           path: ${{ env.ARTIFACTS_DIR }}
 
       - name: Install documentation generation dependencies
-        if: ${{ matrix.shortcut == 'cs9' }}
         run: pip3 install pdoc
 
       - name: Install created sdk
-        if: ${{ matrix.shortcut == 'cs9' }}
         run: pip3 install . -U
 
       - name: Checkout target repository
-        if: ${{ matrix.shortcut == 'cs9' }}
         uses: actions/checkout@v2
         with:
           path: ovirt-engine-sdk
           ref: 'gh-pages'
 
       - name: Create python documentation
-        if: ${{ matrix.shortcut == 'cs9' }}
         run: pdoc -t ovirt-engine-sdk -o ${GEN_DOC_DIR} ovirtsdk4
 
       - name: Upload generated documentation artifacts
-        if: ${{ matrix.shortcut == 'cs9' }}
         uses: actions/upload-artifact@v2
         with:
           name: generated-documentation
@@ -123,7 +110,7 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     container:
-      image: quay.io/centos/centos:stream9
+      image: quay.io/centos/centos:stream8
     steps:
       - name: Download generated documentation artifacts
         uses: actions/download-artifact@v2


### PR DESCRIPTION
Temporarily remove CentOS-9 build, due to problem running
sphinx docgen tool on CentOS-9

Signed-off-by: Ori Liel <oliel@redhat.com>