### PR TITLE
Add checks for non-empty disks when running a backup

### DIFF
--- a/examples/backup_vm.py
+++ b/examples/backup_vm.py
@@ -315,6 +315,9 @@ def start_backup(connection, args):
     else:
         disks = get_vm_disks(connection, args.vm_uuid)
 
+    if not disks:
+        raise RuntimeError("Cannot start a backup without disks")
+
     backup = backups_service.add(
         types.Backup(
             id=args.backup_uuid,


### PR DESCRIPTION
Previously a really not user-friendly error was raised when there were no disks to backup:
i.e., when backup was initiated on a VM without any disks attached.
Both backup script output & engine errors looked like an internal unexpected error rather
then displaying an error message that should help the user to understand what is wrong.
Adding a simple validation and short error message to improve the user experience.

Signed-off-by: Pavel Bar <pbar@redhat.com>