### PR TITLE
Improve backup vm script

### DIFF
--- a/examples/backup_vm.py
+++ b/examples/backup_vm.py
@@ -378,7 +378,7 @@ def download_backup(connection, backup_uuid, args, incremental=False):
 
     backup_disks = backup_service.disks_service().list()
 
-    timestamp = time.strftime("%Y%m%d%H%M")
+    timestamp = time.strftime("%Y%m%d%H%M%S")
     for disk in backup_disks:
         # During incremental backup, incremental backup may not be available
         # for some of the disks. We need to check the backup mode of the disk.

--- a/examples/backup_vm.py
+++ b/examples/backup_vm.py
@@ -381,8 +381,7 @@ def download_backup(connection, backup, args, incremental=False):
     for disk in backup_disks:
         # During incremental backup, incremental backup may not be available
         # for some of the disks. We need to check the backup mode of the disk.
-        backup_mode = get_disk_backup_mode(connection, disk)
-        has_incremental = backup_mode == types.DiskBackupMode.INCREMENTAL
+        has_incremental = disk.backup_mode == types.DiskBackupMode.INCREMENTAL
 
         # If incremental backup is not available, warn about it, since full
         # backup is much slower and takes much more storage.
@@ -390,7 +389,7 @@ def download_backup(connection, backup, args, incremental=False):
             progress("Incremental backup not available for disk %r" % disk.id)
 
         file_name = "{}.{}.{}.{}.qcow2".format(
-            timestamp, backup.to_checkpoint_id, disk.id, backup_mode)
+            timestamp, backup.to_checkpoint_id, disk.id, disk.backup_mode)
         disk_path = os.path.join(args.backup_dir, file_name)
         download_disk(
             connection, backup.id, disk, disk_path, args,
@@ -472,12 +471,6 @@ def get_last_backup_event(connection, search_id):
     # The first item is the most recent event.
     last_event = backup_events[0]
     return dict(code=event.code, description=event.description)
-
-
-def get_disk_backup_mode(connection, disk):
-    system_service = connection.system_service()
-    disk_info = system_service.disks_service().disk_service(disk.id).get()
-    return disk_info.backup_mode
 
 
 def verify_vm_exists(connection, vm_uuid):

--- a/examples/backup_vm.py
+++ b/examples/backup_vm.py
@@ -337,9 +337,7 @@ def start_backup(connection, args):
         backup = get_backup(connection, backup_service, backup.id)
 
     if backup.to_checkpoint_id is not None:
-        progress(
-            "Created checkpoint %r (to use in --from-checkpoint-uuid "
-            "for the next incremental backup)" % backup.to_checkpoint_id)
+        progress("Created checkpoint %r" % backup.to_checkpoint_id)
 
     return backup
 

--- a/examples/backup_vm.py
+++ b/examples/backup_vm.py
@@ -441,7 +441,8 @@ def download_disk(connection, backup_uuid, disk, disk_path, args, incremental=Fa
     finally:
         progress("Finalizing image transfer")
         imagetransfer.finalize_transfer(connection, transfer, disk)
-        progress("Download completed successfully")
+
+    progress("Download completed successfully")
 
 
 # General helpers

--- a/examples/backup_vm.py
+++ b/examples/backup_vm.py
@@ -389,7 +389,8 @@ def download_backup(connection, backup, args, incremental=False):
         if incremental and not has_incremental:
             progress("Incremental backup not available for disk %r" % disk.id)
 
-        file_name = "{}.{}.{}.qcow2".format(disk.id, timestamp, backup_mode)
+        file_name = "{}.{}.{}.{}.qcow2".format(
+            timestamp, backup.to_checkpoint_id, disk.id, backup_mode)
         disk_path = os.path.join(args.backup_dir, file_name)
         download_disk(
             connection, backup.id, disk, disk_path, args,


### PR DESCRIPTION
Various improvements to make it more useful for testing backup.

The most important change is creating a qcow2 chain when downloading
backups. This avoid the need to rebase backup files, which is pretty
hard to do. This makes it very easy to create several incremental
backups and restore any of the backups directly to storage.

To make this possible, we include now the checkpoint id in the
backup file name. This allows finding the previous backup for
the specified checkpoint id.

There are also some minor improvements to logging, backup file names,
and error handling.