### PR TITLE
checkpoints: Add list command

### DIFF
--- a/examples/checkpoints.py
+++ b/examples/checkpoints.py
@@ -20,6 +20,14 @@
 """
 This example shows how to manage VM checkpoints.
 
+To list all checkpoints for a VM:
+
+    ./checkpoints -c engine list vm-id
+
+To list checkpoints older than 1 day:
+
+    ./checkpoints -c engine list --days 1 vm-id
+
 To remove a single checkpoint, use:
 
     ./checkpoints.py -c myengine remove vm-id checkpoint-id
@@ -33,8 +41,9 @@ To remove checkpoints older than 1 day:
     ./checkpoints.py -c myengine purge --days 1 vm-id
 
 """
-import time
 import datetime
+import json
+import time
 
 from contextlib import closing
 
@@ -42,9 +51,23 @@ import ovirtsdk4 as sdk
 from helpers import common
 from helpers.common import progress
 
+
 def main():
     parser = common.ArgumentParser(description="Manage checkpoints")
     subparsers = parser.add_subparsers(title="commands")
+
+    lst = subparsers.add_parser(
+        "list",
+        help="List VM checkpoints.")
+    lst.set_defaults(command=cmd_list)
+    lst.add_argument(
+        "--days",
+        type=int,
+        help="List checkpoints older than specified days. If not "
+             "specified, list all checkpoints.")
+    lst.add_argument(
+        "vm_uuid",
+        help="VM UUID for listing checkpoints.")
 
     remove = subparsers.add_parser(
         "remove",
@@ -75,6 +98,29 @@ def main():
 
     common.configure_logging(args)
     args.command(args)
+
+
+def cmd_list(args):
+    connection = common.create_connection(args)
+    with closing(connection):
+        system_service = connection.system_service()
+        vm_service = system_service.vms_service().vm_service(id=args.vm_uuid)
+        checkpoints_service = vm_service.checkpoints_service()
+
+        now = datetime.datetime.now(datetime.timezone.utc)
+
+        checkpoints = [
+            {
+                "id": checkpoint.id,
+                "creation_date": str(checkpoint.creation_date),
+                "state": str(checkpoint.state),
+                "description": checkpoint.description,
+            }
+            for checkpoint in checkpoints_service.list()
+            if args.days is None or age(checkpoint, now) > args.days
+        ]
+
+    print(json.dumps(checkpoints, indent=2))
 
 
 def cmd_remove(args):

--- a/examples/checkpoints.py
+++ b/examples/checkpoints.py
@@ -111,10 +111,9 @@ def cmd_purge(args):
         now = datetime.datetime.now(datetime.timezone.utc)
 
         for checkpoint in checkpoints_service.list():
-            checkpoint_age = now - checkpoint.creation_date
-
-            if checkpoint_age.days > args.days:
-                progress(f"Removing checkpoint {checkpoint.id}, created {checkpoint_age.days} days ago")
+            days = age(checkpoint, now)
+            if days > args.days:
+                progress(f"Removing checkpoint {checkpoint.id}, created {days} days ago")
                 checkpoint_service = checkpoints_service.checkpoint_service(checkpoint.id)
                 remove_checkpoint(checkpoint_service)
                 progress(f"Checkpoint {checkpoint.id} removed successfully")
@@ -134,6 +133,11 @@ def remove_checkpoint(checkpoint_service, timeout=60):
             raise RuntimeError("Timeout waiting for checkpoint removal")
 
         time.sleep(1)
+
+
+def age(checkpoint, now):
+    delta = now - checkpoint.creation_date
+    return delta.days
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add new command to list checkpoints. Similar to the purge command, it
can list checkpoints older than specified days.
    
This command is useful for managing checkpoints, and an example how to
find checkpoints and use checkpoint properties.