### PR TITLE
Add python38-ovirt-engine-sdk4.spec to build

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -31,7 +31,7 @@ for gen_file in ${GENERATED_FILES} ; do
     < ${gen_file}.in > ${gen_file}
 done
 
-find . -not -name '*.spec' -not -name '*.in' -type f | tar --files-from /proc/self/fd/0 -czf "${TARBALL}" python-ovirt-engine-sdk4.spec
+find . -not -name '*.spec' -not -name '*.in' -type f | tar --files-from /proc/self/fd/0 -czf "${TARBALL}" python-ovirt-engine-sdk4.spec python38-ovirt-engine-sdk4.spec
 
 # Directory, where build artifacts will be stored, should be passed as the 1st parameter
 ARTIFACTS_DIR=${1:-exported-artifacts}

--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -19,6 +19,7 @@ GENERATED_FILES="
  PKG-INFO
  lib/ovirt_engine_sdk_python.egg-info/PKG-INFO
  python-ovirt-engine-sdk4.spec
+ python38-ovirt-engine-sdk4.spec
 "
 
 for gen_file in ${GENERATED_FILES} ; do


### PR DESCRIPTION
We need to reimplement python38-ovirt-engine-sdk4 rpm because of the ansible-core 2.12 requirements.