### PR TITLE
Restore pdoc extension

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,27 +89,20 @@ jobs:
           name: rpm-${{ matrix.shortcut }}
           path: ${{ env.ARTIFACTS_DIR }}
 
-      - name: Install documentation generation dependencies
-        if: ${{ matrix.shortcut == 'cs9' }}
-        run: pip3 install pdoc
-
       - name: Install created sdk
-        if: ${{ matrix.shortcut == 'cs9' }}
+        if: ${{ matrix.shortcut == 'cs8' }}
         run: pip3 install . -U
 
-      - name: Checkout target repository
-        if: ${{ matrix.shortcut == 'cs9' }}
-        uses: actions/checkout@v2
-        with:
-          path: ovirt-engine-sdk
-          ref: 'gh-pages'
-
       - name: Create python documentation
-        if: ${{ matrix.shortcut == 'cs9' }}
-        run: pdoc -t ovirt-engine-sdk -o ${GEN_DOC_DIR} ovirtsdk4
+
+        if: ${{ matrix.shortcut == 'cs8' }}
+        run: |
+          git clone https://github.com/machacekondra/pdoc.git pdoc
+          pip3 install -e ./pdoc -U
+          pdoc --overwrite --html --html-dir=${GEN_DOC_DIR}/
 
       - name: Upload generated documentation artifacts
-        if: ${{ matrix.shortcut == 'cs9' }}
+        if: ${{ matrix.shortcut == 'cs8' }}
         uses: actions/upload-artifact@v2
         with:
           name: generated-documentation


### PR DESCRIPTION
Attempts to replace the propietary pdoc extension for
asciidoc with a standard library with built-in support
for asciidoc have not panned out.

This patch restores the use of the propietary pdoc
extension for generating the python-sdk documentation

Signed-off-by: Ori Liel <oliel@redhat.com>