### PR TITLE
Fix 4.5.1 release packages

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
 VERSION="4.5.1"
-MILESTONE=master
-RPM_RELEASE="0.1.${MILESTONE}.$(date -u +%Y%m%d%H%M%S)"
+MILESTONE=
+RPM_RELEASE="1"
 
 PACKAGE_NAME="python-ovirt-engine-sdk4"
 


### PR DESCRIPTION
The https://github.com/oVirt/python-ovirt-engine-sdk4/pull/67 was changed only in build.sh, to regenerate the rpms we need to also change the build-srpm.sh
