### PR TITLE
Switched some storage examples (using disks_service) to explicitly use python3 and fixed the resulting incompatibilities.

### DIFF
--- a/examples/add_floating_disk.py
+++ b/examples/add_floating_disk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/add_nfs_iso_storage_domain.py
+++ b/examples/add_nfs_iso_storage_domain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/add_vm_disk.py
+++ b/examples/add_vm_disk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/add_vm_from_template_version.py
+++ b/examples/add_vm_from_template_version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #
@@ -28,6 +28,8 @@ logging.basicConfig(level=logging.DEBUG, filename='example.log')
 # This example will connect to the server, and create a virtual machine
 # from a specific version of a template and specify storage domain where
 # virtual machine disk should be created.
+# This example assumes that the template has exactly 1 disk. If it has more
+# disks then the example needs to be adjusted.
 
 # Create the connection to the server:
 connection = sdk.Connection(

--- a/examples/asynchronous_inventory.py
+++ b/examples/asynchronous_inventory.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #
@@ -140,7 +141,7 @@ vms_service = system_service.vms_service()
 # distributed amongst the multiple connections, and will be added to the
 # pipelines. It is necessary to do this block by block because otherwise, if
 # we send all the requests at once, the requests that can't be added to the
-# pipelines of the connections wold be queued in memory, wasting expensive
+# pipelines of the connections would be queued in memory, wasting expensive
 # resources of the underlying library. After sending each block of requests,
 # we need to wait for the responses.
 print('Loading VM disk attachments ...')
@@ -154,7 +155,7 @@ for vms_slice in grouper(vms, block):
         atts_future = atts_service.list(wait=False)
         atts_futures[vm.id] = atts_future
 
-    for vm_id, atts_future in atts_futures.iteritems():
+    for vm_id, atts_future in atts_futures.items():
         vm = vms_index[vm_id]
         vm.disk_attachments = atts_future.wait()
         for att in vm.disk_attachments:
@@ -174,7 +175,7 @@ for vms_slice in grouper(vms, block):
         nics_future = nics_service.list(wait=False)
         nics_futures[vm.id] = nics_future
 
-    for vm_id, nics_future in nics_futures.iteritems():
+    for vm_id, nics_future in nics_futures.items():
         vm = vms_index[vm_id]
         vm.nics = nics_future.wait()
         print("Loaded NICs of VM '%s'." % vm.name)
@@ -192,7 +193,7 @@ for vms_slice in grouper(vms, block):
         devices_future = devices_service.list(wait=False)
         devices_futures[vm.id] = devices_future
 
-    for vm_id, devices_future in devices_futures.iteritems():
+    for vm_id, devices_future in devices_futures.items():
         vm = vms_index[vm_id]
         vm.reported_devices = devices_future.wait()
         print("Loaded reported devices of VM '%s'." % vm.name)

--- a/examples/attach_nfs_data_storage_domain.py
+++ b/examples/attach_nfs_data_storage_domain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/attach_nfs_iso_storage_domain.py
+++ b/examples/attach_nfs_iso_storage_domain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/checksum_disk.py
+++ b/examples/checksum_disk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2020 Red Hat, Inc.
 #

--- a/examples/data_center_maintenance.py
+++ b/examples/data_center_maintenance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/deactivate_disk_attachment.py
+++ b/examples/deactivate_disk_attachment.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/download_disk.py
+++ b/examples/download_disk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/download_disk_snapshot.py
+++ b/examples/download_disk_snapshot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2017 Red Hat, Inc.
 #

--- a/examples/extend_disk.py
+++ b/examples/extend_disk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/image_transfer.py
+++ b/examples/image_transfer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2021 Red Hat, Inc.
 #

--- a/examples/import_glance_image.py
+++ b/examples/import_glance_image.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #
@@ -26,6 +26,8 @@ logging.basicConfig(level=logging.DEBUG, filename='example.log')
 
 # This example shows how to create a new template importing it from an
 # image available in a Glance storage domain.
+
+IMAGE_NAME = 'CirrOS 0.4.0 for x86_64'
 
 # Create the connection to the server:
 connection = sdk.Connection(
@@ -56,7 +58,7 @@ images_service = sd_service.images_service()
 # image we need to retrieve all of them and do the filtering explicitly:
 images = images_service.list()
 image = next(
-    (i for i in images if i.name == 'CirrOS 0.3.4 for x86_64'),
+    (i for i in images if i.name == IMAGE_NAME),
     None
 )
 

--- a/examples/import_vm.py
+++ b/examples/import_vm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #
@@ -27,6 +27,8 @@ logging.basicConfig(level=logging.DEBUG, filename='example.log')
 # This example will import a VM from an export domain using a
 # target domain, the example assumes there is an exported vm in
 # the export storage domain
+# Please note: export domains are deprecated since 4.0, in favor of
+#              regular data domains.
 
 # Create a connection to the server:
 connection = sdk.Connection(

--- a/examples/list_disk_snapshots.py
+++ b/examples/list_disk_snapshots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2017 Red Hat, Inc.
 #

--- a/examples/list_glance_images.py
+++ b/examples/list_glance_images.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/list_vm_snapshots.py
+++ b/examples/list_vm_snapshots.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #
@@ -68,14 +68,14 @@ sds_map = {
 
 # For each virtual machine find its snapshots, then for each snapshot
 # find its disks:
-for vm_id, vm_name in vms_map.iteritems():
+for vm_id, vm_name in vms_map.items():
     vm_service = vms_service.vm_service(vm_id)
     snaps_service = vm_service.snapshots_service()
     snaps_map = {
         snap.id: snap.description
         for snap in snaps_service.list()
     }
-    for snap_id, snap_description in snaps_map.iteritems():
+    for snap_id, snap_description in snaps_map.items():
         snap_service = snaps_service.snapshot_service(snap_id)
         disks_service = snap_service.disks_service()
         for disk in disks_service.list():

--- a/examples/set_vm_lease_storage_domain.py
+++ b/examples/set_vm_lease_storage_domain.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/sparsify_disk.py
+++ b/examples/sparsify_disk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #

--- a/examples/upload_disk.py
+++ b/examples/upload_disk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 #


### PR DESCRIPTION
Switched some storage examples (using disks_service, storage_domains_service and image_transfers_service) to explicitly use python3 and fixed the resulting incompatibilities.

All examples are supposed to use python3 in the end.

Signed-off-by: Rob Linden <rlinden@redhat.com>