### PR TITLE
build: Use ansible-core python version

### DIFF
--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -30,7 +30,7 @@ for gen_file in ${GENERATED_FILES} ; do
     < ${gen_file}.in > ${gen_file}
 done
 
-find . -not -name '*.spec' -not -name '*.in' -type f | tar --files-from /proc/self/fd/0 -czf "${TARBALL}" python-ovirt-engine-sdk4.spec
+find . -not -name '*.spec' -not -name '*.in' -not -name '*.tar.gz' -type f | tar --files-from /proc/self/fd/0 -czf "${TARBALL}" python-ovirt-engine-sdk4.spec
 
 # Directory, where build artifacts will be stored, should be passed as the 1st parameter
 ARTIFACTS_DIR=${1:-exported-artifacts}

--- a/.automation/build-srpm.sh
+++ b/.automation/build-srpm.sh
@@ -12,6 +12,14 @@ PACKAGE_VERSION=${VERSION}
 
 TARBALL="ovirt-engine-sdk-python-${PACKAGE_VERSION}.tar.gz"
 
+# Set correct python version based on ansible-core.
+if [ -z "${ANSIBLE_PYTHON_BIN}" ]; then
+  dnf install -y ansible-core
+  ANSIBLE_PYTHON_BIN=$(rpm -q --requires ansible-core | grep /usr/bin/python)
+fi
+ANSIBLE_PYTHON_RPM=$(rpm -q --qf '%{NAME}' -f "${ANSIBLE_PYTHON_BIN}")
+ANSIBLE_PYTHON_MAJOR_DOT_MINOR=$(rpm -q --requires ansible-core | sed -n 's/python(abi) = //p')
+ANSIBLE_PYTHON_MAJOR_MINOR=$(echo "${ANSIBLE_PYTHON_MAJOR_DOT_MINOR}" | tr -d .)
 
 GENERATED_FILES="
  lib/ovirtsdk4/version.py
@@ -27,6 +35,10 @@ for gen_file in ${GENERATED_FILES} ; do
     -e "s|@RPM_RELEASE@|${RPM_RELEASE}|g" \
     -e "s|@PACKAGE_NAME@|${PACKAGE_NAME}|g" \
     -e "s|@PACKAGE_VERSION@|${PACKAGE_VERSION}|g" \
+    -e "s|@ANSIBLE_PYTHON_BIN@|${ANSIBLE_PYTHON_BIN}|g" \
+    -e "s|@ANSIBLE_PYTHON_RPM@|${ANSIBLE_PYTHON_RPM}|g" \
+    -e "s|@ANSIBLE_PYTHON_MAJOR_DOT_MINOR@|${ANSIBLE_PYTHON_MAJOR_DOT_MINOR}|g" \
+    -e "s|@ANSIBLE_PYTHON_MAJOR_MINOR@|${ANSIBLE_PYTHON_MAJOR_MINOR}|g" \
     < ${gen_file}.in > ${gen_file}
 done
 

--- a/python-ovirt-engine-sdk4.spec.in
+++ b/python-ovirt-engine-sdk4.spec.in
@@ -28,16 +28,16 @@ This package contains the Python 3 SDK for version 4 of the oVirt Engine
 API.
 
 %if 0%{?rhel} < 9
-%package -n python38-ovirt-engine-sdk4
+%package -n @ANSIBLE_PYTHON_RPM@-ovirt-engine-sdk4
 Summary: oVirt Engine Software Development Kit (Python)
-BuildRequires: python38-devel
+BuildRequires: @ANSIBLE_PYTHON_RPM@-devel
 Requires: libxml2
-Requires: python38
-Requires: python38-pycurl >= 7.43.0-6
-Requires: python38-six
+Requires: @ANSIBLE_PYTHON_RPM@
+Requires: @ANSIBLE_PYTHON_RPM@-pycurl >= 7.43.0-6
+Requires: @ANSIBLE_PYTHON_RPM@-six
 
-%description -n python38-ovirt-engine-sdk4
-This package contains the Python 3.8 SDK for version 4 of the oVirt Engine
+%description -n @ANSIBLE_PYTHON_RPM@-ovirt-engine-sdk4
+This package contains the Python @ANSIBLE_PYTHON_MAJOR_DOT_MINOR@ SDK for version 4 of the oVirt Engine
 API.
 %endif
 
@@ -49,8 +49,8 @@ API.
 %define __python3 /usr/bin/python3
 %py3_build
 %if 0%{?rhel} < 9
-%define python3_pkgversion 38
-%define __python3 /usr/bin/python3.8
+%define python3_pkgversion @ANSIBLE_PYTHON_MAJOR_MINOR@
+%define __python3 @ANSIBLE_PYTHON_BIN@
 %py3_build
 %endif
 
@@ -59,8 +59,8 @@ API.
 %define __python3 /usr/bin/python3
 %py3_install
 %if 0%{?rhel} < 9
-%define python3_pkgversion 38
-%define __python3 /usr/bin/python3.8
+%define python3_pkgversion @ANSIBLE_PYTHON_MAJOR_MINOR@
+%define __python3 @ANSIBLE_PYTHON_BIN@
 %py3_install
 %endif
 
@@ -73,12 +73,12 @@ API.
 %{python3_sitearch}/*
 
 %if 0%{?rhel} < 9
-%files -n python38-ovirt-engine-sdk4
+%files -n @ANSIBLE_PYTHON_RPM@-ovirt-engine-sdk4
 %doc README.adoc
 %doc examples
 %license LICENSE.txt
-%define python3_pkgversion 38
-%define __python3 /usr/bin/python3.8
+%define python3_pkgversion @ANSIBLE_PYTHON_MAJOR_MINOR@
+%define __python3 @ANSIBLE_PYTHON_BIN@
 %{python3_sitearch}/*
 %endif
 


### PR DESCRIPTION
Recently ansible-core on CentOS Stream 8 was upgraded from python 3.8 to 3.9. Instead of hard-coding the python version, use the one that ansible-core requires.