### PR TITLE
Auto-publish 4.5 docs upon master changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -209,6 +209,11 @@ jobs:
         run: |
           mkdir -p ./ovirt-engine-sdk/${{env.FOLDER}}/
           cp ./html/ovirtsdk4/* ./ovirt-engine-sdk/${{env.FOLDER}}/
+	  if [[ ${{env.FOLDER}} == "master" ]];
+          then
+            mkdir -p ./ovirt-engine-sdk/4.5/
+            cp ./html/ovirtsdk4/* ./ovirt-engine-sdk/4.5/
+          fi
 
       - name: Push changes to gh-pages
         run: |


### PR DESCRIPTION
As 4.5 branch currently is aligned with master, When master is updated, automatically update the documentation 4.5 branch in gh-pages

Signed-off-by: Ori Liel <oliel@redhat.com>