### PR TITLE
Fix ci libcurl4-openssl 404 status

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -94,6 +94,7 @@ jobs:
       - name: Install Dependencies
       # This step installs dependencies for python-sdk and pdoc
         run: |
+          sudo apt update &&
           sudo apt install -y git \
             python2 \
             python2-dev \


### PR DESCRIPTION
Issue:
```
E: Failed to fetch http://azure.archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl4-openssl-dev_7.68.0-1ubuntu2.15_amd64.deb  404  Not Found [IP: 52.252.75.106 80]
```
Fix: update the system repos before installing 