### PR TITLE
ci: updated build to work with most recent pdoc version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
           - name: centos-stream-9
             shortcut: c9s
             container-name: el9stream
+            pip-command: pip3
 
     name: ${{ matrix.name }}
 
@@ -86,15 +87,15 @@ jobs:
           ref: 'gh-pages'
 
   generate_documentation:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Install Dependencies
       # This step installs dependencies for python-sdk and pdoc
         run: |
           sudo apt update &&
           sudo apt install -y git \
-            python2 \
-            python2-dev \
+            python3 \
+            python3-dev \
             curl \
             asciidoctor \
             gcc \
@@ -109,34 +110,26 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install pip2.7
-        # This step installs pip2.7, which will be needed later
-        run: |
-          curl https://bootstrap.pypa.io/pip/2.7/get-pip.py --output get-pip.py
-          python2 get-pip.py
-
-      - name: Install Python-SDK with Python 2.7
+      - name: Install Python-SDK with Python 3
         # This step installs the python-sdk with python2.7, as the extension of pdoc,
         # which is subsequently installed, doesn't have python3 support.
         run: |
-          pip2.7 install setuptools
+          pip install setuptools
           bash .automation/generate-setup-files.sh
-          python2.7 setup.py install --user --prefix=
+          python3 setup.py install --user --prefix=
         shell: bash
 
       - name: Install Pdoc
         # This steps installs an extension of pdoc which supports asciidoc
         # (this extension runs on python2).
         run: |
-          git clone https://github.com/machacekondra/pdoc
-          cd pdoc
-          pip2.7 install -U .
+          pip install pdoc
 
       - name: Install pygments
-        run: pip2.7 install pygments
+        run: pip install pygments
 
       - name: Generate documentation
-        run: pdoc ovirtsdk4 --html --html-dir=html
+        run: pdoc ovirtsdk4 -o ./${{ env.GEN_DOC_DIR }} -t pdoc
 
       - name: Upload generated documentation artifacts
         uses: actions/upload-artifact@v4
@@ -157,7 +150,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: generated-documentation
-          path: ${{ env.GEN_DOC_DIR }}
+          path: ${{ env.GEN_DOC_DIR }}/
 
       - name: Install package dependencies
         run: |
@@ -197,8 +190,8 @@ jobs:
 
       - name: Move created documentation to gh-pages
         run: |
-          mkdir -p ./ovirt-engine-sdk/${{env.FOLDER}}/
-          cp ./html/ovirtsdk4/* ./ovirt-engine-sdk/${{env.FOLDER}}/
+          mkdir -p ./ovirt-engine-sdk/${{ env.FOLDER }}/
+          cp -r ./${{ env.GEN_DOC_DIR }}/* ./ovirt-engine-sdk/${{ env.FOLDER }}/
 
       - name: Push changes to gh-pages
         run: |

--- a/lib/ovirtsdk4/__init__.py
+++ b/lib/ovirtsdk4/__init__.py
@@ -31,9 +31,11 @@ except ImportError:
     from urllib import urlencode
     from urlparse import urlparse
 
-from ovirtsdk4 import version
 from ovirtsdk4.http import Response
 
+def get_version():
+    from ovirtsdk4 import version
+    return version.VERSION
 
 class Error(Exception):
     """
@@ -44,20 +46,22 @@ class Error(Exception):
     def __init__(self, message, code=None, fault=None):
         """
         Creates an instance of Error class.
-
-        `message`:: The exception message.
-
-        `code`:: An error code associated to the error. For HTTP related
+        """
+        super(Error, self).__init__(message)
+        """
+        Creates an instance of Error class.
+        """
+        self.code = code
+        """
+        An error code associated to the error. For HTTP related
         errors, this will be the HTTP response code returned by the server.
         For example, if retrieving of a virtual machine fails because it
         doesn't exist this attribute will contain the integer value 404. Note
-        that this may be `nil` if the error is not HTTP related.
-
-        `fault`:: The `Fault` object associated to the error.
-        """
-        super(Error, self).__init__(message)
-        self.code = code
+        that this may be `nil` if the error is not HTTP related."""
         self.fault = fault
+        """
+        The `Fault` object associated to the error.
+        """
 
 
 class AuthError(Error):
@@ -230,70 +234,87 @@ class Connection(object):
 
         This method supports the following parameters:
 
-        `url`:: A string containing the base URL of the server, usually
+        `url` \n
+        A string containing the base URL of the server, usually
         something like `https://server.example.com/ovirt-engine/api`.
 
-        `username`:: The name of the user, something like `admin@internal`.
+        `username` \n
+        The name of the user, something like `admin@internal`.
 
-        `password`:: The name password of the user.
+        `password` \n
+        The name password of the user.
 
-        `token`:: : The token to be used to access API. Optionally, user can
+        `token` \n
+        The token to be used to access API. Optionally, user can
         use token, instead of username and password to access API. If user
         don't specify `token` parameter, SDK will automatically create one.
 
-        `insecure`:: A boolean flag that indicates if the server TLS
+        `insecure` \n
+        A boolean flag that indicates if the server TLS
         certificate and host name should be checked.
 
-        `ca_file`:: A PEM file containing the trusted CA certificates. The
+        `ca_file` \n
+        A PEM file containing the trusted CA certificates. The
         certificate presented by the server will be verified using these CA
         certificates. If `ca_file` parameter is not set, system wide
         CA certificate store is used.
 
-        `debug`:: A boolean flag indicating if debug output should be
+        `debug` \n
+        A boolean flag indicating if debug output should be
         generated. If the value is `True` and the `log` parameter isn't
         `None` then the data sent to and received from the server will
         be written to the log. Be aware that user names and passwords will
         also be written, so handle it with care.
 
-        `log`:: The logger where the log messages will be written.
+        `log` \n
+        The logger where the log messages will be written.
 
-        `kerberos`:: A boolean flag indicating if Kerberos
+        `kerberos` \n
+        A boolean flag indicating if Kerberos
         authentication should be used instead of the default basic
         authentication.
 
-        `timeout`:: The maximum total time to wait for the response, in
+        `timeout` \n
+        The maximum total time to wait for the response, in
         seconds. A value of zero (the default) means wait for ever. If
         the timeout expires before the response is received an exception
         will be raised.
 
-        `compress`:: A boolean flag indicating if the SDK should ask
+        `compress` \n
+        A boolean flag indicating if the SDK should ask
         the server to send compressed responses. The default is `True`.
         Note that this is a hint for the server, and that it may return
         uncompressed data even when this parameter is set to `True`.
         Note that compression will be disabled if user pass `debug`
         parameter set to `true`, so the debug messages are in plain text.
 
-        `sso_url`:: A string containing the base SSO URL of the serve.
+        `sso_url` \n
+        A string containing the base SSO URL of the serve.
         Default SSO url is computed from the `url` if no `sso_url` is provided.
 
-        `sso_revoke_url`:: A string containing the base URL of the SSO
+        `sso_revoke_url` \n
+        A string containing the base URL of the SSO
         revoke service. This needs to be specified only when using
         an external authentication service. By default this URL
         is automatically calculated from the value of the `url` parameter,
         so that SSO token revoke will be performed using the SSO service
         that is part of the engine.
 
-        `sso_token_name`:: The token name in the JSON SSO response returned
+        `sso_token_name` \n
+        The token name in the JSON SSO response returned
         from the SSO server. Default value is `access_token`.
 
-        `headers`:: A dictionary with headers which should be send with every
+        `headers` \n
+        A dictionary with headers which should be send with every
         request.
 
-        `connections`:: The maximum number of connections to open to the host.
+        `connections` \n
+        The maximum number of connections to open to the host.
         If the value is `0` (the default) then the number of connections will
         be unlimited.
 
-        `pipeline`:: The maximum number of request to put in an HTTP pipeline
+        `pipeline` \n
+        The maximum number of request to put in an HTTP pipeline
         without waiting for the response. If the value is `0` (the default)
         then pipelining is disabled.
         """
@@ -360,7 +381,8 @@ class Connection(object):
 
         This method supports the following parameters.
 
-        `request`:: The Request object containing the details of the HTTP
+        `request` \n
+        The Request object containing the details of the HTTP
         request to send.
 
         The returned value is a Request object containing the details of the
@@ -445,7 +467,7 @@ class Connection(object):
         for header_name, header_value in headers_dict.items():
             header_lines.append('%s: %s' % (header_name, header_value))
 
-        header_lines.append('User-Agent: PythonSDK/%s' % version.VERSION)
+        header_lines.append('User-Agent: PythonSDK/%s' % get_version())
         header_lines.append('Version: 4')
         header_lines.append('Content-Type: application/xml')
         header_lines.append('Accept: application/xml')
@@ -796,7 +818,7 @@ class Connection(object):
         """
         Releases the resources used by this connection.
 
-        `logout`:: A boolean, which specify if token should be revoked,
+        `logout` A boolean, which specify if token should be revoked,
         and so user should be logged out.
         """
 
@@ -818,10 +840,10 @@ class Connection(object):
 
         This method supports the following parameters:
 
-        `path`:: The path that will be added to the base URL. The default is an
+        `path` The path that will be added to the base URL. The default is an
         empty string.
 
-        `query`:: A dictionary containing the query parameters to add to the
+        `query` A dictionary containing the query parameters to add to the
         URL. The keys of the dictionary should be strings containing the names
         of the parameters, and the values should be strings containing the
         values.
@@ -841,7 +863,7 @@ class Connection(object):
          XML then it does nothing. If it isn't XML then it raises an
          exception.
 
-         `response`:: The HTTP response to check.
+         `response` The HTTP response to check.
         """
         return self._check_content_type(
             self.__XML_CONTENT_TYPE_RE,
@@ -855,7 +877,7 @@ class Connection(object):
          JSON then it does nothing. If it isn't JSON then it raises an
          exception.
 
-         `response`:: The HTTP response to check.
+         `response` The HTTP response to check.
         """
         return self._check_content_type(
             self.__JSON_CONTENT_TYPE_RE,
@@ -868,10 +890,10 @@ class Connection(object):
         Checks the given content type and raises an exception if it isn't the
         expected one.
 
-        `expected_re`:: The regular expression used to check the expected
+        `expected_re` The regular expression used to check the expected
                         content type.
-        `expected_name`:: The name of the expected content type.
-        `headers`:: The HTTP headers to check.
+        `expected_name` The name of the expected content type.
+        `headers` The HTTP headers to check.
         """
         content_type = self._get_header_value(headers, 'content-type')
         if expected_re.match(content_type) is None:
@@ -892,7 +914,7 @@ class Connection(object):
         """
         Read the response.
 
-        `context`:: tuple which contains cur easy, response body,
+        `context` tuple which contains cur easy, response body,
         response headers, original request
         """
         # Extract the response code and body:
@@ -935,8 +957,8 @@ class Connection(object):
         """
         Return header value by its name.
 
-        `headers`:: list of headers
-        `name`:: name of the header
+        `headers` list of headers
+        `name` name of the header
         """
         return next(
             (h.split(':')[1].strip() for h in headers if h.lower().startswith(name)),
@@ -984,8 +1006,7 @@ class ConnectionBuilder(object):
     equivalent to calling the constructor of the `Connection`
     class. Typical use will be like this:
 
-    [source,python]
-    ----
+    ```python
     # Create the builder once:
     builder = ConnectionBuilder(
         url='https://enginer40.example.com/ovirt-engine/api',
@@ -1001,7 +1022,7 @@ class ConnectionBuilder(object):
     # Create and use a second connection:
     with builder.build() as connection:
        ...
-    ----
+    ```
     """
 
     def __init__(self, **kwargs):
@@ -1029,7 +1050,7 @@ class ConnectionBuilder(object):
 #   import ovirtsdk4 as sdk
 #   vm = sdk.types.Vm()
 #
-from ovirtsdk4 import readers  # noqa: F401
-from ovirtsdk4 import services  # noqa: F401
-from ovirtsdk4 import types  # noqa: F401
-from ovirtsdk4 import writers  # noqa: F401
+import ovirtsdk4.readers as readers  # noqa: F401
+import ovirtsdk4.writers as writers  # noqa: F401
+import ovirtsdk4.types as types  # noqa: F401
+import ovirtsdk4.services as services  # noqa: F401

--- a/lib/ovirtsdk4/readers.py
+++ b/lib/ovirtsdk4/readers.py
@@ -23,6 +23,8 @@ from ovirtsdk4.reader import Reader
 
 
 class ActionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ActionReader, self).__init__()
@@ -281,6 +283,8 @@ class ActionReader(Reader):
 
 
 class AffinityGroupReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(AffinityGroupReader, self).__init__()
@@ -405,6 +409,8 @@ class AffinityGroupReader(Reader):
 
 
 class AffinityLabelReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(AffinityLabelReader, self).__init__()
@@ -574,6 +580,8 @@ class AffinityRuleReader(Reader):
 
 
 class AgentReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(AgentReader, self).__init__()
@@ -666,6 +674,8 @@ class AgentReader(Reader):
 
 
 class AgentConfigurationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(AgentConfigurationReader, self).__init__()
@@ -741,6 +751,8 @@ class AgentConfigurationReader(Reader):
 
 
 class ApiReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ApiReader, self).__init__()
@@ -816,6 +828,8 @@ class ApiReader(Reader):
 
 
 class ApiSummaryReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ApiSummaryReader, self).__init__()
@@ -887,6 +901,8 @@ class ApiSummaryReader(Reader):
 
 
 class ApiSummaryItemReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ApiSummaryItemReader, self).__init__()
@@ -954,6 +970,8 @@ class ApiSummaryItemReader(Reader):
 
 
 class ApplicationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ApplicationReader, self).__init__()
@@ -1028,6 +1046,8 @@ class ApplicationReader(Reader):
 
 
 class AuthorizedKeyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(AuthorizedKeyReader, self).__init__()
@@ -1104,6 +1124,8 @@ class AuthorizedKeyReader(Reader):
 
 
 class BackupReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(BackupReader, self).__init__()
@@ -1209,6 +1231,8 @@ class BackupReader(Reader):
 
 
 class BalanceReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(BalanceReader, self).__init__()
@@ -1285,6 +1309,8 @@ class BalanceReader(Reader):
 
 
 class BiosReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(BiosReader, self).__init__()
@@ -1352,6 +1378,8 @@ class BiosReader(Reader):
 
 
 class BlockStatisticReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(BlockStatisticReader, self).__init__()
@@ -1417,6 +1445,8 @@ class BlockStatisticReader(Reader):
 
 
 class BondingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(BondingReader, self).__init__()
@@ -1488,6 +1518,8 @@ class BondingReader(Reader):
 
 
 class BookmarkReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(BookmarkReader, self).__init__()
@@ -1562,6 +1594,8 @@ class BookmarkReader(Reader):
 
 
 class BootReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(BootReader, self).__init__()
@@ -1627,6 +1661,8 @@ class BootReader(Reader):
 
 
 class BootMenuReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(BootMenuReader, self).__init__()
@@ -1692,6 +1728,8 @@ class BootMenuReader(Reader):
 
 
 class BrickProfileDetailReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(BrickProfileDetailReader, self).__init__()
@@ -1759,6 +1797,8 @@ class BrickProfileDetailReader(Reader):
 
 
 class CdromReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CdromReader, self).__init__()
@@ -1856,6 +1896,8 @@ class CdromReader(Reader):
 
 
 class CertificateReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CertificateReader, self).__init__()
@@ -1934,6 +1976,8 @@ class CertificateReader(Reader):
 
 
 class CheckpointReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CheckpointReader, self).__init__()
@@ -2031,6 +2075,8 @@ class CheckpointReader(Reader):
 
 
 class CloudInitReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CloudInitReader, self).__init__()
@@ -2108,6 +2154,8 @@ class CloudInitReader(Reader):
 
 
 class ClusterReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ClusterReader, self).__init__()
@@ -2325,6 +2373,8 @@ class ClusterReader(Reader):
 
 
 class ClusterFeatureReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ClusterFeatureReader, self).__init__()
@@ -2399,6 +2449,8 @@ class ClusterFeatureReader(Reader):
 
 
 class ClusterLevelReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ClusterLevelReader, self).__init__()
@@ -2492,6 +2544,8 @@ class ClusterLevelReader(Reader):
 
 
 class ConfigurationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ConfigurationReader, self).__init__()
@@ -2559,6 +2613,8 @@ class ConfigurationReader(Reader):
 
 
 class ConsoleReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ConsoleReader, self).__init__()
@@ -2624,6 +2680,8 @@ class ConsoleReader(Reader):
 
 
 class CoreReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CoreReader, self).__init__()
@@ -2691,6 +2749,8 @@ class CoreReader(Reader):
 
 
 class CpuReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CpuReader, self).__init__()
@@ -2772,6 +2832,8 @@ class CpuReader(Reader):
 
 
 class CpuProfileReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CpuProfileReader, self).__init__()
@@ -2865,6 +2927,8 @@ class CpuProfileReader(Reader):
 
 
 class CpuTopologyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CpuTopologyReader, self).__init__()
@@ -2934,6 +2998,8 @@ class CpuTopologyReader(Reader):
 
 
 class CpuTuneReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CpuTuneReader, self).__init__()
@@ -2999,6 +3065,8 @@ class CpuTuneReader(Reader):
 
 
 class CpuTypeReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CpuTypeReader, self).__init__()
@@ -3068,6 +3136,8 @@ class CpuTypeReader(Reader):
 
 
 class CustomPropertyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(CustomPropertyReader, self).__init__()
@@ -3137,6 +3207,8 @@ class CustomPropertyReader(Reader):
 
 
 class DataCenterReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DataCenterReader, self).__init__()
@@ -3282,6 +3354,8 @@ class DataCenterReader(Reader):
 
 
 class DeviceReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DeviceReader, self).__init__()
@@ -3377,6 +3451,8 @@ class DeviceReader(Reader):
 
 
 class DiskReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DiskReader, self).__init__()
@@ -3562,6 +3638,8 @@ class DiskReader(Reader):
 
 
 class DiskAttachmentReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DiskAttachmentReader, self).__init__()
@@ -3654,6 +3732,8 @@ class DiskAttachmentReader(Reader):
 
 
 class DiskProfileReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DiskProfileReader, self).__init__()
@@ -3747,6 +3827,8 @@ class DiskProfileReader(Reader):
 
 
 class DiskSnapshotReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DiskSnapshotReader, self).__init__()
@@ -3936,6 +4018,8 @@ class DiskSnapshotReader(Reader):
 
 
 class DisplayReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DisplayReader, self).__init__()
@@ -4029,6 +4113,8 @@ class DisplayReader(Reader):
 
 
 class DnsReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DnsReader, self).__init__()
@@ -4096,6 +4182,8 @@ class DnsReader(Reader):
 
 
 class DnsResolverConfigurationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DnsResolverConfigurationReader, self).__init__()
@@ -4161,6 +4249,8 @@ class DnsResolverConfigurationReader(Reader):
 
 
 class DomainReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DomainReader, self).__init__()
@@ -4259,6 +4349,8 @@ class DomainReader(Reader):
 
 
 class DynamicCpuReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(DynamicCpuReader, self).__init__()
@@ -4326,6 +4418,8 @@ class DynamicCpuReader(Reader):
 
 
 class EntityProfileDetailReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(EntityProfileDetailReader, self).__init__()
@@ -4391,6 +4485,8 @@ class EntityProfileDetailReader(Reader):
 
 
 class ErrorHandlingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ErrorHandlingReader, self).__init__()
@@ -4456,6 +4552,8 @@ class ErrorHandlingReader(Reader):
 
 
 class EventReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(EventReader, self).__init__()
@@ -4562,6 +4660,8 @@ class EventReader(Reader):
 
 
 class EventSubscriptionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(EventSubscriptionReader, self).__init__()
@@ -4642,6 +4742,8 @@ class EventSubscriptionReader(Reader):
 
 
 class ExternalComputeResourceReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ExternalComputeResourceReader, self).__init__()
@@ -4722,6 +4824,8 @@ class ExternalComputeResourceReader(Reader):
 
 
 class ExternalDiscoveredHostReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ExternalDiscoveredHostReader, self).__init__()
@@ -4804,6 +4908,8 @@ class ExternalDiscoveredHostReader(Reader):
 
 
 class ExternalHostReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ExternalHostReader, self).__init__()
@@ -4880,6 +4986,8 @@ class ExternalHostReader(Reader):
 
 
 class ExternalHostGroupReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ExternalHostGroupReader, self).__init__()
@@ -4962,6 +5070,8 @@ class ExternalHostGroupReader(Reader):
 
 
 class ExternalHostProviderReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ExternalHostProviderReader, self).__init__()
@@ -5091,6 +5201,8 @@ class ExternalHostProviderReader(Reader):
 
 
 class ExternalNetworkProviderConfigurationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ExternalNetworkProviderConfigurationReader, self).__init__()
@@ -5167,6 +5279,8 @@ class ExternalNetworkProviderConfigurationReader(Reader):
 
 
 class ExternalProviderReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ExternalProviderReader, self).__init__()
@@ -5251,6 +5365,8 @@ class ExternalProviderReader(Reader):
 
 
 class ExternalTemplateImportReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ExternalTemplateImportReader, self).__init__()
@@ -5330,6 +5446,8 @@ class ExternalTemplateImportReader(Reader):
 
 
 class ExternalVmImportReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ExternalVmImportReader, self).__init__()
@@ -5419,6 +5537,8 @@ class ExternalVmImportReader(Reader):
 
 
 class FaultReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(FaultReader, self).__init__()
@@ -5486,6 +5606,8 @@ class FaultReader(Reader):
 
 
 class FencingPolicyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(FencingPolicyReader, self).__init__()
@@ -5559,6 +5681,8 @@ class FencingPolicyReader(Reader):
 
 
 class FileReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(FileReader, self).__init__()
@@ -5637,6 +5761,8 @@ class FileReader(Reader):
 
 
 class FilterReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(FilterReader, self).__init__()
@@ -5713,6 +5839,8 @@ class FilterReader(Reader):
 
 
 class FloppyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(FloppyReader, self).__init__()
@@ -5810,6 +5938,8 @@ class FloppyReader(Reader):
 
 
 class FopStatisticReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(FopStatisticReader, self).__init__()
@@ -5877,6 +6007,8 @@ class FopStatisticReader(Reader):
 
 
 class GlusterBrickReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GlusterBrickReader, self).__init__()
@@ -6001,6 +6133,8 @@ class GlusterBrickReader(Reader):
 
 
 class GlusterBrickAdvancedDetailsReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GlusterBrickAdvancedDetailsReader, self).__init__()
@@ -6110,6 +6244,8 @@ class GlusterBrickAdvancedDetailsReader(Reader):
 
 
 class GlusterBrickMemoryInfoReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GlusterBrickMemoryInfoReader, self).__init__()
@@ -6175,6 +6311,8 @@ class GlusterBrickMemoryInfoReader(Reader):
 
 
 class GlusterClientReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GlusterClientReader, self).__init__()
@@ -6246,6 +6384,8 @@ class GlusterClientReader(Reader):
 
 
 class GlusterHookReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GlusterHookReader, self).__init__()
@@ -6353,6 +6493,8 @@ class GlusterHookReader(Reader):
 
 
 class GlusterMemoryPoolReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GlusterMemoryPoolReader, self).__init__()
@@ -6441,6 +6583,8 @@ class GlusterMemoryPoolReader(Reader):
 
 
 class GlusterServerHookReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GlusterServerHookReader, self).__init__()
@@ -6521,6 +6665,8 @@ class GlusterServerHookReader(Reader):
 
 
 class GlusterVolumeReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GlusterVolumeReader, self).__init__()
@@ -6635,6 +6781,8 @@ class GlusterVolumeReader(Reader):
 
 
 class GlusterVolumeProfileDetailsReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GlusterVolumeProfileDetailsReader, self).__init__()
@@ -6711,6 +6859,8 @@ class GlusterVolumeProfileDetailsReader(Reader):
 
 
 class GracePeriodReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GracePeriodReader, self).__init__()
@@ -6776,6 +6926,8 @@ class GracePeriodReader(Reader):
 
 
 class GraphicsConsoleReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GraphicsConsoleReader, self).__init__()
@@ -6862,6 +7014,8 @@ class GraphicsConsoleReader(Reader):
 
 
 class GroupReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GroupReader, self).__init__()
@@ -6971,6 +7125,8 @@ class GroupReader(Reader):
 
 
 class GuestOperatingSystemReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(GuestOperatingSystemReader, self).__init__()
@@ -7046,6 +7202,8 @@ class GuestOperatingSystemReader(Reader):
 
 
 class HardwareInformationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HardwareInformationReader, self).__init__()
@@ -7123,6 +7281,8 @@ class HardwareInformationReader(Reader):
 
 
 class HighAvailabilityReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HighAvailabilityReader, self).__init__()
@@ -7190,6 +7350,8 @@ class HighAvailabilityReader(Reader):
 
 
 class HookReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HookReader, self).__init__()
@@ -7268,6 +7430,8 @@ class HookReader(Reader):
 
 
 class HostReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HostReader, self).__init__()
@@ -7538,6 +7702,8 @@ class HostReader(Reader):
 
 
 class HostCpuUnitReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HostCpuUnitReader, self).__init__()
@@ -7635,6 +7801,8 @@ class HostCpuUnitReader(Reader):
 
 
 class HostDeviceReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HostDeviceReader, self).__init__()
@@ -7731,6 +7899,8 @@ class HostDeviceReader(Reader):
 
 
 class HostDevicePassthroughReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HostDevicePassthroughReader, self).__init__()
@@ -7796,6 +7966,8 @@ class HostDevicePassthroughReader(Reader):
 
 
 class HostNicReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HostNicReader, self).__init__()
@@ -7936,6 +8108,8 @@ class HostNicReader(Reader):
 
 
 class HostNicVirtualFunctionsConfigurationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HostNicVirtualFunctionsConfigurationReader, self).__init__()
@@ -8005,6 +8179,8 @@ class HostNicVirtualFunctionsConfigurationReader(Reader):
 
 
 class HostStorageReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HostStorageReader, self).__init__()
@@ -8115,6 +8291,8 @@ class HostStorageReader(Reader):
 
 
 class HostedEngineReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(HostedEngineReader, self).__init__()
@@ -8188,6 +8366,8 @@ class HostedEngineReader(Reader):
 
 
 class IconReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(IconReader, self).__init__()
@@ -8264,6 +8444,8 @@ class IconReader(Reader):
 
 
 class IdentifiedReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(IdentifiedReader, self).__init__()
@@ -8336,6 +8518,8 @@ class IdentifiedReader(Reader):
 
 
 class ImageReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ImageReader, self).__init__()
@@ -8414,6 +8598,8 @@ class ImageReader(Reader):
 
 
 class ImageTransferReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ImageTransferReader, self).__init__()
@@ -8516,6 +8702,8 @@ class ImageTransferReader(Reader):
 
 
 class InitializationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(InitializationReader, self).__init__()
@@ -8623,6 +8811,8 @@ class InitializationReader(Reader):
 
 
 class InstanceTypeReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(InstanceTypeReader, self).__init__()
@@ -8861,6 +9051,8 @@ class InstanceTypeReader(Reader):
 
 
 class IoReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(IoReader, self).__init__()
@@ -8926,6 +9118,8 @@ class IoReader(Reader):
 
 
 class IpReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(IpReader, self).__init__()
@@ -8997,6 +9191,8 @@ class IpReader(Reader):
 
 
 class IpAddressAssignmentReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(IpAddressAssignmentReader, self).__init__()
@@ -9064,6 +9260,8 @@ class IpAddressAssignmentReader(Reader):
 
 
 class IscsiBondReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(IscsiBondReader, self).__init__()
@@ -9162,6 +9360,8 @@ class IscsiBondReader(Reader):
 
 
 class IscsiDetailsReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(IscsiDetailsReader, self).__init__()
@@ -9259,6 +9459,8 @@ class IscsiDetailsReader(Reader):
 
 
 class JobReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(JobReader, self).__init__()
@@ -9362,6 +9564,8 @@ class JobReader(Reader):
 
 
 class KatelloErratumReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(KatelloErratumReader, self).__init__()
@@ -9452,6 +9656,8 @@ class KatelloErratumReader(Reader):
 
 
 class KernelReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(KernelReader, self).__init__()
@@ -9517,6 +9723,8 @@ class KernelReader(Reader):
 
 
 class KsmReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(KsmReader, self).__init__()
@@ -9584,6 +9792,8 @@ class KsmReader(Reader):
 
 
 class LinkLayerDiscoveryProtocolElementReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(LinkLayerDiscoveryProtocolElementReader, self).__init__()
@@ -9664,6 +9874,8 @@ class LinkLayerDiscoveryProtocolElementReader(Reader):
 
 
 class LogicalUnitReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(LogicalUnitReader, self).__init__()
@@ -9766,6 +9978,8 @@ class LogicalUnitReader(Reader):
 
 
 class MDevTypeReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(MDevTypeReader, self).__init__()
@@ -9837,6 +10051,8 @@ class MDevTypeReader(Reader):
 
 
 class MacReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(MacReader, self).__init__()
@@ -9902,6 +10118,8 @@ class MacReader(Reader):
 
 
 class MacPoolReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(MacPoolReader, self).__init__()
@@ -9997,6 +10215,8 @@ class MacPoolReader(Reader):
 
 
 class MemoryOverCommitReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(MemoryOverCommitReader, self).__init__()
@@ -10062,6 +10282,8 @@ class MemoryOverCommitReader(Reader):
 
 
 class MemoryPolicyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(MemoryPolicyReader, self).__init__()
@@ -10135,6 +10357,8 @@ class MemoryPolicyReader(Reader):
 
 
 class MethodReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(MethodReader, self).__init__()
@@ -10195,6 +10419,8 @@ class MethodReader(Reader):
 
 
 class MigrationBandwidthReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(MigrationBandwidthReader, self).__init__()
@@ -10262,6 +10488,8 @@ class MigrationBandwidthReader(Reader):
 
 
 class MigrationOptionsReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(MigrationOptionsReader, self).__init__()
@@ -10339,6 +10567,8 @@ class MigrationOptionsReader(Reader):
 
 
 class MigrationPolicyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(MigrationPolicyReader, self).__init__()
@@ -10411,6 +10641,8 @@ class MigrationPolicyReader(Reader):
 
 
 class NetworkReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NetworkReader, self).__init__()
@@ -10548,6 +10780,8 @@ class NetworkReader(Reader):
 
 
 class NetworkAttachmentReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NetworkAttachmentReader, self).__init__()
@@ -10638,6 +10872,8 @@ class NetworkAttachmentReader(Reader):
 
 
 class NetworkConfigurationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NetworkConfigurationReader, self).__init__()
@@ -10705,6 +10941,8 @@ class NetworkConfigurationReader(Reader):
 
 
 class NetworkFilterReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NetworkFilterReader, self).__init__()
@@ -10779,6 +11017,8 @@ class NetworkFilterReader(Reader):
 
 
 class NetworkFilterParameterReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NetworkFilterParameterReader, self).__init__()
@@ -10855,6 +11095,8 @@ class NetworkFilterParameterReader(Reader):
 
 
 class NetworkLabelReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NetworkLabelReader, self).__init__()
@@ -10931,6 +11173,8 @@ class NetworkLabelReader(Reader):
 
 
 class NfsProfileDetailReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NfsProfileDetailReader, self).__init__()
@@ -10998,6 +11242,8 @@ class NfsProfileDetailReader(Reader):
 
 
 class NicReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NicReader, self).__init__()
@@ -11160,6 +11406,8 @@ class NicReader(Reader):
 
 
 class NicConfigurationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NicConfigurationReader, self).__init__()
@@ -11235,6 +11483,8 @@ class NicConfigurationReader(Reader):
 
 
 class NumaNodeReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NumaNodeReader, self).__init__()
@@ -11334,6 +11584,8 @@ class NumaNodeReader(Reader):
 
 
 class NumaNodePinReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(NumaNodePinReader, self).__init__()
@@ -11403,6 +11655,8 @@ class NumaNodePinReader(Reader):
 
 
 class OpenStackImageReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OpenStackImageReader, self).__init__()
@@ -11477,6 +11731,8 @@ class OpenStackImageReader(Reader):
 
 
 class OpenStackImageProviderReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OpenStackImageProviderReader, self).__init__()
@@ -11587,6 +11843,8 @@ class OpenStackImageProviderReader(Reader):
 
 
 class OpenStackNetworkReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OpenStackNetworkReader, self).__init__()
@@ -11661,6 +11919,8 @@ class OpenStackNetworkReader(Reader):
 
 
 class OpenStackNetworkProviderReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OpenStackNetworkProviderReader, self).__init__()
@@ -11798,6 +12058,8 @@ class OpenStackNetworkProviderReader(Reader):
 
 
 class OpenStackProviderReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OpenStackProviderReader, self).__init__()
@@ -11884,6 +12146,8 @@ class OpenStackProviderReader(Reader):
 
 
 class OpenStackSubnetReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OpenStackSubnetReader, self).__init__()
@@ -11966,6 +12230,8 @@ class OpenStackSubnetReader(Reader):
 
 
 class OpenStackVolumeProviderReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OpenStackVolumeProviderReader, self).__init__()
@@ -12085,6 +12351,8 @@ class OpenStackVolumeProviderReader(Reader):
 
 
 class OpenStackVolumeTypeReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OpenStackVolumeTypeReader, self).__init__()
@@ -12161,6 +12429,8 @@ class OpenStackVolumeTypeReader(Reader):
 
 
 class OpenstackVolumeAuthenticationKeyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OpenstackVolumeAuthenticationKeyReader, self).__init__()
@@ -12243,6 +12513,8 @@ class OpenstackVolumeAuthenticationKeyReader(Reader):
 
 
 class OperatingSystemReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OperatingSystemReader, self).__init__()
@@ -12322,6 +12594,8 @@ class OperatingSystemReader(Reader):
 
 
 class OperatingSystemInfoReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OperatingSystemInfoReader, self).__init__()
@@ -12402,6 +12676,8 @@ class OperatingSystemInfoReader(Reader):
 
 
 class OptionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(OptionReader, self).__init__()
@@ -12471,6 +12747,8 @@ class OptionReader(Reader):
 
 
 class PackageReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(PackageReader, self).__init__()
@@ -12536,6 +12814,8 @@ class PackageReader(Reader):
 
 
 class PayloadReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(PayloadReader, self).__init__()
@@ -12605,6 +12885,8 @@ class PayloadReader(Reader):
 
 
 class PermissionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(PermissionReader, self).__init__()
@@ -12699,6 +12981,8 @@ class PermissionReader(Reader):
 
 
 class PermitReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(PermitReader, self).__init__()
@@ -12775,6 +13059,8 @@ class PermitReader(Reader):
 
 
 class PmProxyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(PmProxyReader, self).__init__()
@@ -12840,6 +13126,8 @@ class PmProxyReader(Reader):
 
 
 class PortMirroringReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(PortMirroringReader, self).__init__()
@@ -12897,6 +13185,8 @@ class PortMirroringReader(Reader):
 
 
 class PowerManagementReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(PowerManagementReader, self).__init__()
@@ -12982,6 +13272,8 @@ class PowerManagementReader(Reader):
 
 
 class ProductReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ProductReader, self).__init__()
@@ -13054,6 +13346,8 @@ class ProductReader(Reader):
 
 
 class ProductInfoReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ProductInfoReader, self).__init__()
@@ -13125,6 +13419,8 @@ class ProductInfoReader(Reader):
 
 
 class ProfileDetailReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ProfileDetailReader, self).__init__()
@@ -13198,6 +13494,8 @@ class ProfileDetailReader(Reader):
 
 
 class PropertyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(PropertyReader, self).__init__()
@@ -13265,6 +13563,8 @@ class PropertyReader(Reader):
 
 
 class ProxyTicketReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ProxyTicketReader, self).__init__()
@@ -13330,6 +13630,8 @@ class ProxyTicketReader(Reader):
 
 
 class QosReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(QosReader, self).__init__()
@@ -13438,6 +13740,8 @@ class QosReader(Reader):
 
 
 class QuotaReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(QuotaReader, self).__init__()
@@ -13557,6 +13861,8 @@ class QuotaReader(Reader):
 
 
 class QuotaClusterLimitReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(QuotaClusterLimitReader, self).__init__()
@@ -13641,6 +13947,8 @@ class QuotaClusterLimitReader(Reader):
 
 
 class QuotaStorageLimitReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(QuotaStorageLimitReader, self).__init__()
@@ -13721,6 +14029,8 @@ class QuotaStorageLimitReader(Reader):
 
 
 class RangeReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RangeReader, self).__init__()
@@ -13788,6 +14098,8 @@ class RangeReader(Reader):
 
 
 class RateReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RateReader, self).__init__()
@@ -13855,6 +14167,8 @@ class RateReader(Reader):
 
 
 class RegistrationAffinityGroupMappingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RegistrationAffinityGroupMappingReader, self).__init__()
@@ -13922,6 +14236,8 @@ class RegistrationAffinityGroupMappingReader(Reader):
 
 
 class RegistrationAffinityLabelMappingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RegistrationAffinityLabelMappingReader, self).__init__()
@@ -13989,6 +14305,8 @@ class RegistrationAffinityLabelMappingReader(Reader):
 
 
 class RegistrationClusterMappingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RegistrationClusterMappingReader, self).__init__()
@@ -14056,6 +14374,8 @@ class RegistrationClusterMappingReader(Reader):
 
 
 class RegistrationConfigurationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RegistrationConfigurationReader, self).__init__()
@@ -14133,6 +14453,8 @@ class RegistrationConfigurationReader(Reader):
 
 
 class RegistrationDomainMappingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RegistrationDomainMappingReader, self).__init__()
@@ -14200,6 +14522,8 @@ class RegistrationDomainMappingReader(Reader):
 
 
 class RegistrationLunMappingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RegistrationLunMappingReader, self).__init__()
@@ -14267,6 +14591,8 @@ class RegistrationLunMappingReader(Reader):
 
 
 class RegistrationRoleMappingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RegistrationRoleMappingReader, self).__init__()
@@ -14334,6 +14660,8 @@ class RegistrationRoleMappingReader(Reader):
 
 
 class RegistrationVnicProfileMappingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RegistrationVnicProfileMappingReader, self).__init__()
@@ -14401,6 +14729,8 @@ class RegistrationVnicProfileMappingReader(Reader):
 
 
 class ReportedConfigurationReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ReportedConfigurationReader, self).__init__()
@@ -14472,6 +14802,8 @@ class ReportedConfigurationReader(Reader):
 
 
 class ReportedDeviceReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ReportedDeviceReader, self).__init__()
@@ -14552,6 +14884,8 @@ class ReportedDeviceReader(Reader):
 
 
 class RngDeviceReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RngDeviceReader, self).__init__()
@@ -14619,6 +14953,8 @@ class RngDeviceReader(Reader):
 
 
 class RoleReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(RoleReader, self).__init__()
@@ -14714,6 +15050,8 @@ class RoleReader(Reader):
 
 
 class SchedulingPolicyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SchedulingPolicyReader, self).__init__()
@@ -14823,6 +15161,8 @@ class SchedulingPolicyReader(Reader):
 
 
 class SchedulingPolicyUnitReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SchedulingPolicyUnitReader, self).__init__()
@@ -14903,6 +15243,8 @@ class SchedulingPolicyUnitReader(Reader):
 
 
 class SeLinuxReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SeLinuxReader, self).__init__()
@@ -14968,6 +15310,8 @@ class SeLinuxReader(Reader):
 
 
 class SerialNumberReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SerialNumberReader, self).__init__()
@@ -15035,6 +15379,8 @@ class SerialNumberReader(Reader):
 
 
 class SessionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SessionReader, self).__init__()
@@ -15117,6 +15463,8 @@ class SessionReader(Reader):
 
 
 class SkipIfConnectivityBrokenReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SkipIfConnectivityBrokenReader, self).__init__()
@@ -15184,6 +15532,8 @@ class SkipIfConnectivityBrokenReader(Reader):
 
 
 class SkipIfSdActiveReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SkipIfSdActiveReader, self).__init__()
@@ -15249,6 +15599,8 @@ class SkipIfSdActiveReader(Reader):
 
 
 class SnapshotReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SnapshotReader, self).__init__()
@@ -15610,6 +15962,8 @@ class SnapshotReader(Reader):
 
 
 class SpecialObjectsReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SpecialObjectsReader, self).__init__()
@@ -15677,6 +16031,8 @@ class SpecialObjectsReader(Reader):
 
 
 class SpmReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SpmReader, self).__init__()
@@ -15744,6 +16100,8 @@ class SpmReader(Reader):
 
 
 class SshReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SshReader, self).__init__()
@@ -15826,6 +16184,8 @@ class SshReader(Reader):
 
 
 class SshPublicKeyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SshPublicKeyReader, self).__init__()
@@ -15902,6 +16262,8 @@ class SshPublicKeyReader(Reader):
 
 
 class SsoReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SsoReader, self).__init__()
@@ -15967,6 +16329,8 @@ class SsoReader(Reader):
 
 
 class StatisticReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(StatisticReader, self).__init__()
@@ -16065,6 +16429,8 @@ class StatisticReader(Reader):
 
 
 class StepReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(StepReader, self).__init__()
@@ -16176,6 +16542,8 @@ class StepReader(Reader):
 
 
 class StorageConnectionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(StorageConnectionReader, self).__init__()
@@ -16278,6 +16646,8 @@ class StorageConnectionReader(Reader):
 
 
 class StorageConnectionExtensionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(StorageConnectionExtensionReader, self).__init__()
@@ -16358,6 +16728,8 @@ class StorageConnectionExtensionReader(Reader):
 
 
 class StorageDomainReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(StorageDomainReader, self).__init__()
@@ -16550,6 +16922,8 @@ class StorageDomainReader(Reader):
 
 
 class StorageDomainLeaseReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(StorageDomainLeaseReader, self).__init__()
@@ -16615,6 +16989,8 @@ class StorageDomainLeaseReader(Reader):
 
 
 class SystemOptionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SystemOptionReader, self).__init__()
@@ -16689,6 +17065,8 @@ class SystemOptionReader(Reader):
 
 
 class SystemOptionValueReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(SystemOptionValueReader, self).__init__()
@@ -16756,6 +17134,8 @@ class SystemOptionValueReader(Reader):
 
 
 class TagReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(TagReader, self).__init__()
@@ -16840,6 +17220,8 @@ class TagReader(Reader):
 
 
 class TemplateReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(TemplateReader, self).__init__()
@@ -17078,6 +17460,8 @@ class TemplateReader(Reader):
 
 
 class TemplateVersionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(TemplateVersionReader, self).__init__()
@@ -17147,6 +17531,8 @@ class TemplateVersionReader(Reader):
 
 
 class TicketReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(TicketReader, self).__init__()
@@ -17214,6 +17600,8 @@ class TicketReader(Reader):
 
 
 class TimeZoneReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(TimeZoneReader, self).__init__()
@@ -17281,6 +17669,8 @@ class TimeZoneReader(Reader):
 
 
 class TransparentHugePagesReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(TransparentHugePagesReader, self).__init__()
@@ -17346,6 +17736,8 @@ class TransparentHugePagesReader(Reader):
 
 
 class UnmanagedNetworkReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(UnmanagedNetworkReader, self).__init__()
@@ -17422,6 +17814,8 @@ class UnmanagedNetworkReader(Reader):
 
 
 class UsbReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(UsbReader, self).__init__()
@@ -17489,6 +17883,8 @@ class UsbReader(Reader):
 
 
 class UserReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(UserReader, self).__init__()
@@ -17635,6 +18031,8 @@ class UserReader(Reader):
 
 
 class UserOptionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(UserOptionReader, self).__init__()
@@ -17711,6 +18109,8 @@ class UserOptionReader(Reader):
 
 
 class ValueReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(ValueReader, self).__init__()
@@ -17778,6 +18178,8 @@ class ValueReader(Reader):
 
 
 class VcpuPinReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VcpuPinReader, self).__init__()
@@ -17845,6 +18247,8 @@ class VcpuPinReader(Reader):
 
 
 class VendorReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VendorReader, self).__init__()
@@ -17917,6 +18321,8 @@ class VendorReader(Reader):
 
 
 class VersionReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VersionReader, self).__init__()
@@ -17999,6 +18405,8 @@ class VersionReader(Reader):
 
 
 class VirtioScsiReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VirtioScsiReader, self).__init__()
@@ -18064,6 +18472,8 @@ class VirtioScsiReader(Reader):
 
 
 class VirtualNumaNodeReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VirtualNumaNodeReader, self).__init__()
@@ -18169,6 +18579,8 @@ class VirtualNumaNodeReader(Reader):
 
 
 class VlanReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VlanReader, self).__init__()
@@ -18229,6 +18641,8 @@ class VlanReader(Reader):
 
 
 class VmReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VmReader, self).__init__()
@@ -18573,6 +18987,8 @@ class VmReader(Reader):
 
 
 class VmBaseReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VmBaseReader, self).__init__()
@@ -18739,6 +19155,8 @@ class VmBaseReader(Reader):
 
 
 class VmMediatedDeviceReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VmMediatedDeviceReader, self).__init__()
@@ -18836,6 +19254,8 @@ class VmMediatedDeviceReader(Reader):
 
 
 class VmPlacementPolicyReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VmPlacementPolicyReader, self).__init__()
@@ -18918,6 +19338,8 @@ class VmPlacementPolicyReader(Reader):
 
 
 class VmPoolReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VmPoolReader, self).__init__()
@@ -19037,6 +19459,8 @@ class VmPoolReader(Reader):
 
 
 class VmSummaryReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VmSummaryReader, self).__init__()
@@ -19106,6 +19530,8 @@ class VmSummaryReader(Reader):
 
 
 class VnicPassThroughReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VnicPassThroughReader, self).__init__()
@@ -19171,6 +19597,8 @@ class VnicPassThroughReader(Reader):
 
 
 class VnicProfileReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VnicProfileReader, self).__init__()
@@ -19276,6 +19704,8 @@ class VnicProfileReader(Reader):
 
 
 class VnicProfileMappingReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VnicProfileMappingReader, self).__init__()
@@ -19345,6 +19775,8 @@ class VnicProfileMappingReader(Reader):
 
 
 class VolumeGroupReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(VolumeGroupReader, self).__init__()
@@ -19415,6 +19847,8 @@ class VolumeGroupReader(Reader):
 
 
 class WatchdogReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(WatchdogReader, self).__init__()
@@ -19514,6 +19948,8 @@ class WatchdogReader(Reader):
 
 
 class WeightReader(Reader):
+    """
+    """
 
     def __init__(self):
         super(WeightReader, self).__init__()

--- a/lib/ovirtsdk4/service.py
+++ b/lib/ovirtsdk4/service.py
@@ -36,10 +36,13 @@ class Future(object):
         """
         Creates a new future result.
 
-        `connection`:: The connection to be used by this future.
-        `context`:: The request that this future will wait for when the `wait`
+        `connection` \n
+        The connection to be used by this future.
+        `context` \n
+        The request that this future will wait for when the `wait`
         method is called.
-        `code`:: The function that will be executed to check the response, and
+        `code` \n
+        The function that will be executed to check the response, and
         to convert its body into the right type of object.
         """
         self._connection = connection

--- a/lib/ovirtsdk4/services.py
+++ b/lib/ovirtsdk4/services.py
@@ -46,27 +46,30 @@ class AffinityGroupService(Service):
     ):
         """
         Retrieve the affinity group details.
-        [source,xml]
-        ----
+        ```xml
         <affinity_group id="00000000-0000-0000-0000-000000000000">
           <name>AF_GROUP_001</name>
           <cluster id="00000000-0000-0000-0000-000000000000"/>
           <positive>true</positive>
           <enforcing>true</enforcing>
         </affinity_group>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -91,21 +94,22 @@ class AffinityGroupService(Service):
     ):
         """
         Remove the affinity group.
-        [source]
-        ----
+        ```
         DELETE /ovirt-engine/api/clusters/000-000/affinitygroups/123-456
-        ----
-
-
+        ```
         This method supports the following parameters:
 
-        `async_`:: Indicates if the removal should be performed asynchronously.
+        `async_` \n
+        Indicates if the removal should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -140,13 +144,14 @@ class AffinityGroupService(Service):
 
         This method supports the following parameters:
 
-        `group`:: The affinity group.
-
-        `headers`:: Additional HTTP headers.
-
-        `query`:: Additional URL query parameters.
-
-        `wait`:: If `True` wait for the response.
+        `group` \n
+        The affinity group.
+        `headers` \n
+        Additional HTTP headers.
+        `query` \n
+        Additional URL query parameters.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -254,13 +259,17 @@ class AffinityGroupHostService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the removal should be performed asynchronously.
+        `async_` \n
+        Indicates if the removal should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -315,13 +324,17 @@ class AffinityGroupHostLabelService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the removal should be performed asynchronously.
+        `async_` \n
+        Indicates if the removal should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -375,25 +388,27 @@ class AffinityGroupHostLabelsService(Service):
         Adds a host label to the affinity group.
         For example, to add the label `789` to the affinity group `456` of cluster `123`,
         send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/clusters/123/affinitygroups/456/hostlabels
-        ....
+        ```
         With the following body:
-        [source,xml]
-        ----
+        ```xml
         <affinity_label id="789"/>
-        ----
-
+        ```
 
         This method supports the following parameters:
 
-        `label`:: The AffinityLabel object to add to the affinity group.
+        `label` \n
+        The AffinityLabel object to add to the affinity group.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -419,20 +434,24 @@ class AffinityGroupHostLabelsService(Service):
         List all host labels assigned to this affinity group.
         The order of the returned labels isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of host labels to return.
+        `max` \n
+        Sets the maximum number of host labels to return.
         If not specified, all the labels are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -498,25 +517,27 @@ class AffinityGroupHostsService(Service):
         Adds a host to the affinity group.
         For example, to add the host `789` to the affinity group `456` of cluster `123`, send a request like
         this:
-        ....
+        ```
         POST /ovirt-engine/api/clusters/123/affinitygroups/456/hosts
-        ....
+        ```
         With the following body:
-        [source,xml]
-        ----
+        ```xml
         <host id="789"/>
-        ----
-
+        ```
 
         This method supports the following parameters:
 
-        `host`:: The host to be added to the affinity group.
+        `host` \n
+        The host to be added to the affinity group.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -542,20 +563,23 @@ class AffinityGroupHostsService(Service):
         List all hosts assigned to this affinity group.
         The order of the returned hosts isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of hosts to return. If not specified, all the hosts are
-        returned.
+        `max` \n
+        Sets the maximum number of hosts to return. If not specified, all the hosts are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -622,13 +646,17 @@ class AffinityGroupVmService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the removal should be performed asynchronously.
+        `async_` \n
+        Indicates if the removal should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -683,13 +711,17 @@ class AffinityGroupVmLabelService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the removal should be performed asynchronously.
+        `async_` \n
+        Indicates if the removal should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -743,25 +775,28 @@ class AffinityGroupVmLabelsService(Service):
         Adds a virtual machine label to the affinity group.
         For example, to add the label `789` to the affinity group `456` of cluster `123`,
         send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/clusters/123/affinitygroups/456/vmlabels
-        ....
+        ```
         With the following body:
-        [source,xml]
-        ----
+        ```xml
         <affinity_label id="789"/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `label`:: The AffinityLabel object to add to the affinity group.
+        `label` \n
+        The AffinityLabel object to add to the affinity group.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -787,20 +822,24 @@ class AffinityGroupVmLabelsService(Service):
         List all virtual machine labels assigned to this affinity group.
         The order of the returned labels isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of virtual machine labels to return.
+        `max` \n
+        Sets the maximum number of virtual machine labels to return.
         If not specified, all the labels are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -822,7 +861,6 @@ class AffinityGroupVmLabelsService(Service):
     def label_service(self, id):
         """
         Access the service that manages the virtual machine label assignment to this affinity group.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -847,7 +885,6 @@ class AffinityGroupVmLabelsService(Service):
 class AffinityGroupVmsService(Service):
     """
     This service manages a collection of all the virtual machines assigned to an affinity group.
-
     """
 
     def __init__(self, connection, path):
@@ -866,16 +903,13 @@ class AffinityGroupVmsService(Service):
         Adds a virtual machine to the affinity group.
         For example, to add the virtual machine `789` to the affinity group `456` of cluster `123`, send a request like
         this:
-        ....
+        ```
         POST /ovirt-engine/api/clusters/123/affinitygroups/456/vms
-        ....
+        ```
         With the following body:
-        [source,xml]
-        ----
+        ```xml
         <vm id="789"/>
-        ----
-
-
+        ```
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -901,20 +935,23 @@ class AffinityGroupVmsService(Service):
         List all virtual machines assigned to this affinity group.
         The order of the returned virtual machines isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of virtual machines to return. If not specified, all the virtual machines are
-        returned.
+        `max` \n
+        Sets the maximum number of virtual machines to return. If not specified, all the virtual machines are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -936,7 +973,6 @@ class AffinityGroupVmsService(Service):
     def vm_service(self, id):
         """
         Access the service that manages the virtual machine assignment to this affinity group.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -961,7 +997,6 @@ class AffinityGroupVmsService(Service):
 class AffinityGroupsService(Service):
     """
     The affinity groups service manages virtual machine relationships and dependencies.
-
     """
 
     def __init__(self, connection, path):
@@ -979,13 +1014,11 @@ class AffinityGroupsService(Service):
         """
         Create a new affinity group.
         Post a request like in the example below to create a new affinity group:
-        [source]
-        ----
+        ```
         POST /ovirt-engine/api/clusters/000-000/affinitygroups
-        ----
+        ```
         And use the following example in its body:
-        [source,xml]
-        ----
+        ```xml
         <affinity_group>
           <name>AF_GROUP_001</name>
           <hosts_rule>
@@ -996,18 +1029,21 @@ class AffinityGroupsService(Service):
             <enabled>false</enabled>
           </vms_rule>
         </affinity_group>
-        ----
-
+        ```
 
         This method supports the following parameters:
 
-        `group`:: The affinity group object to create.
+        `group` \n
+        The affinity group object to create.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1033,19 +1069,23 @@ class AffinityGroupsService(Service):
         List existing affinity groups.
         The order of the affinity groups results isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of affinity groups to return. If not specified all the affinity groups are returned.
+        `max` \n
+        Sets the maximum number of affinity groups to return. If not specified all the affinity groups are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1067,7 +1107,6 @@ class AffinityGroupsService(Service):
     def group_service(self, id):
         """
         Access the affinity group service that manages the affinity group specified by an ID.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -1092,7 +1131,6 @@ class AffinityGroupsService(Service):
 class AffinityLabelService(Service):
     """
     The details of a single affinity label.
-
     """
 
     def __init__(self, connection, path):
@@ -1111,17 +1149,20 @@ class AffinityLabelService(Service):
         """
         Retrieves the details of a label.
 
-
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1146,8 +1187,6 @@ class AffinityLabelService(Service):
         """
         Removes a label from the system and clears all assignments
         of the removed label.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1170,8 +1209,6 @@ class AffinityLabelService(Service):
         """
         Updates a label. This call will update all metadata, such as the name
         or description.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1187,14 +1224,12 @@ class AffinityLabelService(Service):
     def hosts_service(self):
         """
         List all hosts with this label.
-
         """
         return AffinityLabelHostsService(self._connection, '%s/hosts' % self._path)
 
     def vms_service(self):
         """
         List all virtual machines with this label.
-
         """
         return AffinityLabelVmsService(self._connection, '%s/vms' % self._path)
 
@@ -1223,9 +1258,7 @@ class AffinityLabelHostService(Service):
     This service represents a host that has a specific
     label when accessed through the affinitylabels/hosts
     subcollection.
-
     """
-
     def __init__(self, connection, path):
         super(AffinityLabelHostService, self).__init__(connection, path)
 
@@ -1240,17 +1273,20 @@ class AffinityLabelHostService(Service):
         """
         Retrieves details about a host that has this label assigned.
 
-
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1274,8 +1310,6 @@ class AffinityLabelHostService(Service):
     ):
         """
         Remove a label from a host.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1304,7 +1338,6 @@ class AffinityLabelHostsService(Service):
     This service represents list of hosts that have a specific
     label when accessed through the affinitylabels/hosts
     subcollection.
-
     """
 
     def __init__(self, connection, path):
@@ -1321,8 +1354,6 @@ class AffinityLabelHostsService(Service):
     ):
         """
         Add a label to a host.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1347,17 +1378,20 @@ class AffinityLabelHostsService(Service):
         List all hosts with the label.
         The order of the returned hosts isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1376,7 +1410,6 @@ class AffinityLabelHostsService(Service):
         """
         A link to the specific label-host assignment to
         allow label removal.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -1403,7 +1436,6 @@ class AffinityLabelVmService(Service):
     This service represents a vm that has a specific
     label when accessed through the affinitylabels/vms
     subcollection.
-
     """
 
     def __init__(self, connection, path):
@@ -1420,17 +1452,20 @@ class AffinityLabelVmService(Service):
         """
         Retrieves details about a vm that has this label assigned.
 
-
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1454,8 +1489,6 @@ class AffinityLabelVmService(Service):
     ):
         """
         Remove a label from a vm.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1484,7 +1517,6 @@ class AffinityLabelVmsService(Service):
     This service represents list of vms that have a specific
     label when accessed through the affinitylabels/vms
     subcollection.
-
     """
 
     def __init__(self, connection, path):
@@ -1501,8 +1533,6 @@ class AffinityLabelVmsService(Service):
     ):
         """
         Add a label to a vm.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1527,17 +1557,20 @@ class AffinityLabelVmsService(Service):
         List all virtual machines with the label.
         The order of the returned virtual machines isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1556,7 +1589,6 @@ class AffinityLabelVmsService(Service):
         """
         A link to the specific label-vm assignment to
         allow label removal.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -1581,7 +1613,6 @@ class AffinityLabelVmsService(Service):
 class AffinityLabelsService(Service):
     """
     Manages the affinity labels available in the system.
-
     """
 
     def __init__(self, connection, path):
@@ -1599,8 +1630,6 @@ class AffinityLabelsService(Service):
         """
         Creates a new label. The label is automatically attached
         to all entities mentioned in the vms or hosts lists.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1626,19 +1655,23 @@ class AffinityLabelsService(Service):
         Lists all labels present in the system.
         The order of the returned labels isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of labels to return. If not specified all the labels are returned.
+        `max` \n
+        Sets the maximum number of labels to return. If not specified all the labels are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1660,7 +1693,6 @@ class AffinityLabelsService(Service):
     def label_service(self, id):
         """
         Link to a single label details.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -1694,7 +1726,6 @@ class AreaService(Service):
     A concept may be associated to more than one area, or to no area.
     The value of this annotation is intended for reporting only, and it doesn't affect at all the generated code or the
     validity of the model
-
     """
 
     def __init__(self, connection, path):
@@ -1716,7 +1747,6 @@ class AssignedAffinityLabelService(Service):
     """
     This service represents one label to entity assignment
     when accessed using the entities/affinitylabels subcollection.
-
     """
 
     def __init__(self, connection, path):
@@ -1733,17 +1763,20 @@ class AssignedAffinityLabelService(Service):
         """
         Retrieves details about the attached label.
 
-
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1767,8 +1800,6 @@ class AssignedAffinityLabelService(Service):
     ):
         """
         Removes the label from an entity. Does not touch the label itself.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1796,7 +1827,6 @@ class AssignedAffinityLabelsService(Service):
     """
     This service is used to list and manipulate affinity labels that are
     assigned to supported entities when accessed using entities/affinitylabels.
-
     """
 
     def __init__(self, connection, path):
@@ -1813,8 +1843,6 @@ class AssignedAffinityLabelsService(Service):
     ):
         """
         Attaches a label to an entity.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1839,17 +1867,20 @@ class AssignedAffinityLabelsService(Service):
         Lists all labels that are attached to an entity.
         The order of the returned entities isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1868,7 +1899,6 @@ class AssignedAffinityLabelsService(Service):
         """
         Link to the specific entity-label assignment to allow
         removal.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -1908,14 +1938,18 @@ class AssignedCpuProfileService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1941,13 +1975,17 @@ class AssignedCpuProfileService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -1997,8 +2035,6 @@ class AssignedCpuProfilesService(Service):
     ):
         """
         Add a new cpu profile for the cluster.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2024,19 +2060,23 @@ class AssignedCpuProfilesService(Service):
         List the CPU profiles assigned to the cluster.
         The order of the returned CPU profiles isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of profiles to return. If not specified all the profiles are returned.
+        `max` \n
+        Sets the maximum number of profiles to return. If not specified all the profiles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2056,8 +2096,6 @@ class AssignedCpuProfilesService(Service):
         return self._internal_get(headers, query, wait)
 
     def profile_service(self, id):
-        """
-        """
         Service._check_types([
             ('id', id, str),
         ])
@@ -2096,14 +2134,18 @@ class AssignedDiskProfileService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2129,13 +2171,17 @@ class AssignedDiskProfileService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2185,8 +2231,6 @@ class AssignedDiskProfilesService(Service):
     ):
         """
         Add a new disk profile for the storage domain.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2212,19 +2256,23 @@ class AssignedDiskProfilesService(Service):
         Returns the list of disk profiles assigned to the storage domain.
         The order of the returned disk profiles isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of profiles to return. If not specified all the profiles are returned.
+        `max` \n
+        Sets the maximum number of profiles to return. If not specified all the profiles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2269,7 +2317,6 @@ class AssignedDiskProfilesService(Service):
 class AssignedPermissionsService(Service):
     """
     Represents a permission sub-collection, scoped by user, group or some entity type.
-
     """
 
     def __init__(self, connection, path):
@@ -2288,60 +2335,59 @@ class AssignedPermissionsService(Service):
         Assign a new permission to a user or group for specific entity.
         For example, to assign the `UserVmManager` role to the virtual machine with id `123` to the user with id `456`
         send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/vms/123/permissions
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        ```xml
         <permission>
           <role>
             <name>UserVmManager</name>
           </role>
           <user id="456"/>
         </permission>
-        ----
+        ```
         To assign the `SuperUser` role to the system to the user with id `456` send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/permissions
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        ```xml
         <permission>
           <role>
             <name>SuperUser</name>
           </role>
           <user id="456"/>
         </permission>
-        ----
+        ```
         If you want to assign permission to the group instead of the user please replace the `user` element with the
         `group` element with proper `id` of the group. For example to assign the `UserRole` role to the cluster with
         id `123` to the group with id `789` send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/clusters/123/permissions
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        ```xml
         <permission>
           <role>
             <name>UserRole</name>
           </role>
           <group id="789"/>
         </permission>
-        ----
-
-
+        ```
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2365,16 +2411,19 @@ class AssignedPermissionsService(Service):
         """
         Add a new permission on the cluster to the group in the system.
 
-
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2398,16 +2447,19 @@ class AssignedPermissionsService(Service):
         """
         Add a new permission on the data center to the group in the system.
 
-
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2431,16 +2483,19 @@ class AssignedPermissionsService(Service):
         """
         Add a new group level permission for a given virtual machine.
 
-
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2464,16 +2519,19 @@ class AssignedPermissionsService(Service):
         """
         Add a new permission on the host to the group in the system.
 
-
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2497,11 +2555,11 @@ class AssignedPermissionsService(Service):
         """
         List all the permissions of the specific entity.
         For example to list all the permissions of the cluster with id `123` send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/clusters/123/permissions
-        ....
-        [source,xml]
-        ----
+        ```
+        With a request body like this:
+        ```xml
         <permissions>
           <permission id="456">
             <cluster id="123"/>
@@ -2514,20 +2572,23 @@ class AssignedPermissionsService(Service):
             <group id="127"/>
           </permission>
         </permissions>
-        ----
+        ```
         The order of the returned permissions isn't guaranteed.
-
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2553,16 +2614,19 @@ class AssignedPermissionsService(Service):
         """
         Add a new permission on the storage domain to the group in the system.
 
-
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2586,16 +2650,19 @@ class AssignedPermissionsService(Service):
         """
         Add a new permission on the template to the group in the system.
 
-
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2619,16 +2686,19 @@ class AssignedPermissionsService(Service):
         """
         Add a new user level permission for a given virtual machine.
 
-
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2652,16 +2722,19 @@ class AssignedPermissionsService(Service):
         """
         Add a new permission on the vm to the group in the system.
 
-
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2685,16 +2758,19 @@ class AssignedPermissionsService(Service):
         """
         Add a new permission on the vm pool to the group in the system.
 
-
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2711,7 +2787,6 @@ class AssignedPermissionsService(Service):
         """
         Sub-resource locator method, returns individual permission resource on which the remainder of the URI is
         dispatched.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -2736,7 +2811,6 @@ class AssignedPermissionsService(Service):
 class AssignedRolesService(Service):
     """
     Represents a roles sub-collection, for example scoped by user.
-
     """
 
     def __init__(self, connection, path):
@@ -2756,19 +2830,23 @@ class AssignedRolesService(Service):
         Returns the roles assigned to the permission.
         The order of the returned roles isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of roles to return. If not specified all the roles are returned.
+        `max` \n
+        Sets the maximum number of roles to return. If not specified all the roles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2790,7 +2868,6 @@ class AssignedRolesService(Service):
     def role_service(self, id):
         """
         Sub-resource locator method, returns individual role resource on which the remainder of the URI is dispatched.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -2815,7 +2892,6 @@ class AssignedRolesService(Service):
 class AssignedTagService(Service):
     """
     A service to manage assignment of specific tag to specific entities in system.
-
     """
 
     def __init__(self, connection, path):
@@ -2833,29 +2909,31 @@ class AssignedTagService(Service):
         Gets the information about the assigned tag.
         For example to retrieve the information about the tag with the id `456` which is assigned to virtual machine
         with id `123` send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/vms/123/tags/456
-        ....
-        [source,xml]
-        ----
+        ```
+        results in a response body like this:
+        ```xml
         <tag href="/ovirt-engine/api/tags/456" id="456">
           <name>root</name>
           <description>root</description>
           <vm href="/ovirt-engine/api/vms/123" id="123"/>
         </tag>
-        ----
-
-
+        ```
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2881,20 +2959,23 @@ class AssignedTagService(Service):
         """
         Unassign tag from specific entity in the system.
         For example to unassign the tag with id `456` from virtual machine with id `123` send a request like this:
-        ....
+        ```
         DELETE /ovirt-engine/api/vms/123/tags/456
-        ....
-
+        ```
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2947,27 +3028,30 @@ class AssignedTagsService(Service):
         """
         Assign tag to specific entity in the system.
         For example to assign tag `mytag` to virtual machine with the id `123` send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/vms/123/tags
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        ```xml
         <tag>
           <name>mytag</name>
         </tag>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `tag`:: The assigned tag.
+        `tag` \n
+        The assigned tag.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -2992,11 +3076,11 @@ class AssignedTagsService(Service):
         """
         List all tags assigned to the specific entity.
         For example to list all the tags of the virtual machine with id `123` send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/vms/123/tags
-        ....
-        [source,xml]
-        ----
+        ```
+        Results in a response body like this:
+        ```xml
         <tags>
           <tag href="/ovirt-engine/api/tags/222" id="222">
             <name>mytag</name>
@@ -3004,22 +3088,26 @@ class AssignedTagsService(Service):
             <vm href="/ovirt-engine/api/vms/123" id="123"/>
           </tag>
         </tags>
-        ----
+        ```
         The order of the returned tags isn't guaranteed.
-
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of tags to return. If not specified all the tags are returned.
+        `max` \n
+        Sets the maximum number of tags to return. If not specified all the tags are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3041,7 +3129,6 @@ class AssignedTagsService(Service):
     def tag_service(self, id):
         """
         Reference to the service that manages assignment of specific tag.
-
         """
         Service._check_types([
             ('id', id, str),
@@ -3082,14 +3169,18 @@ class AssignedVnicProfileService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3115,13 +3206,17 @@ class AssignedVnicProfileService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3142,8 +3237,6 @@ class AssignedVnicProfileService(Service):
         self._internal_remove(headers, query, wait)
 
     def permissions_service(self):
-        """
-        """
         return AssignedPermissionsService(self._connection, '%s/permissions' % self._path)
 
     def service(self, path):
@@ -3180,8 +3273,6 @@ class AssignedVnicProfilesService(Service):
     ):
         """
         Add a new virtual network interface card profile for the network.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3207,19 +3298,23 @@ class AssignedVnicProfilesService(Service):
         Returns the list of VNIC profiles assifned to the network.
         The order of the returned VNIC profiles isn't guaranteed.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of profiles to return. If not specified all the profiles are returned.
+        `max` \n
+        Sets the maximum number of profiles to return. If not specified all the profiles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3239,8 +3334,6 @@ class AssignedVnicProfilesService(Service):
         return self._internal_get(headers, query, wait)
 
     def profile_service(self, id):
-        """
-        """
         Service._check_types([
             ('id', id, str),
         ])
@@ -3280,27 +3373,28 @@ class AttachedStorageDomainService(Service):
         """
         This operation activates an attached storage domain.
         Once the storage domain is activated it is ready for use with the data center.
-        [source]
-        ----
+        ```
         POST /ovirt-engine/api/datacenters/123/storagedomains/456/activate
-        ----
+        ```
         The activate action does not take any action specific parameters,
         so the request body should contain an empty `action`:
-        [source,xml]
-        ----
+        ```xml
         <action/>
-        ----
-
+        ```
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the activation should be performed asynchronously.
+        `async_` \n
+        Indicates if the activation should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3332,45 +3426,53 @@ class AttachedStorageDomainService(Service):
         This operation deactivates an attached storage domain.
         Once the storage domain is deactivated it will not be used with the data center.
         For example, to deactivate storage domain `456`, send the following request:
-        [source]
-        ----
+
+        ```
         POST /ovirt-engine/api/datacenters/123/storagedomains/456/deactivate
-        ----
+        ```
+
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```xml
         <action/>
-        ----
+        ```
+
         If the `force` parameter is `true` then the operation will succeed, even if the OVF update which takes place
         before the deactivation of the storage domain failed. If the `force` parameter is `false` and the OVF update failed,
         the deactivation of the storage domain will also fail.
 
-
         This method supports the following parameters:
 
-        `async_`:: Indicates if the deactivation should be performed asynchronously.
+        `async_` \n
+        Indicates if the deactivation should be performed asynchronously.
 
-        `force`:: Indicates if the operation should succeed and the storage domain should be moved to a deactivated state, even if
+        `force` \n
+        Indicates if the operation should succeed and the storage domain should be moved to a deactivated state, even if
         the OVF update for the storage domain failed.
+
         For example, to deactivate storage domain `456` using force flag, send the following request:
-        [source]
-        ----
+
+        ```
         POST /ovirt-engine/api/datacenters/123/storagedomains/456/deactivate
-        ----
+        ```
+
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```
         <action>
           <force>true</force>
         <action>
-        ----
+        ```
         This parameter is optional, and the default value is `false`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3402,14 +3504,18 @@ class AttachedStorageDomainService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3435,13 +3541,17 @@ class AttachedStorageDomainService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3504,21 +3614,24 @@ class AttachedStorageDomainDisksService(Service):
         """
         Adds or registers a disk.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To add a new disk use the xref:services-disks-methods-add[add]
+        compatibility. It will be removed in the future. To add a new disk use the `DisksService.add`
         operation of the service that manages the disks of the system. To register an unregistered disk use the
-        xref:services-attached_storage_domain_disk-methods-register[register] operation of the service that manages
-        that disk.
+        `AttachedStorageDomainDiskService.register` operation of the service that manages that disk.
 
 
         This method supports the following parameters:
 
-        `disk`:: The disk to add or register.
+        `disk` \n
+        The disk to add or register.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3550,16 +3663,21 @@ class AttachedStorageDomainDisksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of disks to return. If not specified all the disks are returned.
+        `max` \n
+        Sets the maximum number of disks to return. If not specified all the disks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3627,13 +3745,17 @@ class AttachedStorageDomainsService(Service):
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain to attach to the data center.
+        `storage_domain` \n
+        The storage domain to attach to the data center.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3662,16 +3784,21 @@ class AttachedStorageDomainsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of storage domains to return. If not specified all the storage domains are returned.
+        `max` \n
+        Sets the maximum number of storage domains to return. If not specified all the storage domains are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3732,16 +3859,21 @@ class BalanceService(Service):
         """
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3771,13 +3903,17 @@ class BalanceService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3858,18 +3994,24 @@ class BalancesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of balances to return. If not specified all the balances are returned.
+        `max` \n
+        Sets the maximum number of balances to return. If not specified all the balances are returned.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3935,29 +4077,33 @@ class BookmarkService(Service):
         """
         Get a bookmark.
         An example for getting a bookmark:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/bookmarks/123
-        ----
-        [source,xml]
-        ----
+        ```
+
+        ```xml
         <bookmark href="/ovirt-engine/api/bookmarks/123" id="123">
           <name>example_vm</name>
           <value>vm: name=example*</value>
         </bookmark>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -3983,21 +4129,25 @@ class BookmarkService(Service):
         """
         Remove a bookmark.
         An example for removing a bookmark:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/bookmarks/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4029,29 +4179,33 @@ class BookmarkService(Service):
         """
         Update a bookmark.
         An example for updating a bookmark:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/bookmarks/123
-        ----
+        ```
         With the request body:
-        [source,xml]
-        ----
+
+        ```xml
         <bookmark>
           <name>new_example_vm</name>
           <value>vm: name=new_example*</value>
         </bookmark>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `bookmark`:: The updated bookmark.
+        `bookmark` \n
+        The updated bookmark.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4105,28 +4259,32 @@ class BookmarksService(Service):
         """
         Adding a new bookmark.
         Example of adding a bookmark:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/bookmarks
-        ----
-        [source,xml]
-        ----
+        ```
+
+        ```xml
         <bookmark>
           <name>new_example_vm</name>
           <value>vm: name=new_example*</value>
         </bookmark>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `bookmark`:: The added bookmark.
+        `bookmark` \n
+        The added bookmark.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4151,12 +4309,13 @@ class BookmarksService(Service):
         """
         Listing all the available bookmarks.
         Example of listing bookmarks:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/bookmarks
-        ----
-        [source,xml]
-        ----
+        ```
+        The response will be similar to:
+
+        ```xml
         <bookmarks>
           <bookmark href="/ovirt-engine/api/bookmarks/123" id="123">
             <name>database</name>
@@ -4167,22 +4326,27 @@ class BookmarksService(Service):
             <value>vm: name=example*</value>
           </bookmark>
         </bookmarks>
-        ----
+        ```
         The order of the returned bookmarks isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of bookmarks to return. If not specified all the bookmarks are returned.
+        `max` \n
+        Sets the maximum number of bookmarks to return. If not specified all the bookmarks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4256,12 +4420,12 @@ class ClusterService(Service):
         """
         Gets information about the cluster.
         An example of getting a cluster:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusters/123
-        ----
-        [source,xml]
-        ----
+        ```
+
+        ```xml
         <cluster href="/ovirt-engine/api/clusters/123" id="123">
           <actions>
             <link href="/ovirt-engine/api/clusters/123/resetemulatedmachine" rel="resetemulatedmachine"/>
@@ -4327,21 +4491,26 @@ class ClusterService(Service):
           <virt_service>true</virt_service>
           <data_center href="/ovirt-engine/api/datacenters/111" id="111"/>
         </cluster>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4371,10 +4540,10 @@ class ClusterService(Service):
         Refresh the Gluster heal info for all volumes in cluster.
         For example, Cluster `123`, send a request like
         this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/123/refreshglusterhealstatus
-        ----
+        ```
 
 
         """
@@ -4399,21 +4568,25 @@ class ClusterService(Service):
     ):
         """
         Removes the cluster from the system.
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/clusters/00000000-0000-0000-0000-000000000000
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4444,13 +4617,17 @@ class ClusterService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the reset should be performed asynchronously.
+        `async_` \n
+        Indicates if the reset should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4479,26 +4656,30 @@ class ClusterService(Service):
     ):
         """
         Synchronizes all networks on the cluster.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/123/syncallnetworks
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4530,19 +4711,19 @@ class ClusterService(Service):
         Updates information about the cluster.
         Only the specified fields are updated; others remain unchanged.
         For example, to update the cluster's CPU:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/clusters/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```xml
         <cluster>
           <cpu>
             <type>Intel Haswell-noTSX Family</type>
           </cpu>
         </cluster>
-        ----
+        ```
 
 
         """
@@ -4580,22 +4761,22 @@ class ClusterService(Service):
         Start, update or finish upgrade process for the cluster based on the action value. This action marks the
         cluster for upgrade, updates the progress, or clears the upgrade running flag on the cluster based on the
         action value which takes values of `start`, `stop` or `update_progress`.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/123/upgrade
-        ----
+        ```
         With a request body like this to mark the cluster for upgrade:
-        [source,xml]
-        ----
+
+        ```xml
         <action>
             <upgrade_action>
                 start
             </upgrade_action>
         </action>
-        ----
+        ```
         After starting the upgrade, use a request body like this to update the progress to 15%:
-        [source,xml]
-        ----
+
+        ```xml
         <action>
             <upgrade_action>
                 update_progress
@@ -4604,26 +4785,33 @@ class ClusterService(Service):
                 15
             </upgrade_percent_complete>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `upgrade_action`:: The action to be performed.
+        `upgrade_action` \n
+        The action to be performed.
 
-        `correlation_id`:: Explicitly set the upgrade correlation identifier.  Use to correlate events
+        `correlation_id` \n
+        Explicitly set the upgrade correlation identifier.  Use to correlate events
         detailing the cluster upgrade to the upgrade itself.  If not specificed, the
         correlation id from `Correlation-Id` http header will be used.
 
-        `upgrade_percent_complete`:: Update the upgrade's progress as a percent complete of the total process.
+        `upgrade_percent_complete` \n
+        Update the upgrade's progress as a percent complete of the total process.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4779,29 +4967,33 @@ class ClusterEnabledFeatureService(Service):
         """
         Provides the information about the cluster feature enabled.
         For example, to find details of the enabled feature `456` for cluster `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusters/123/enabledfeatures/456
-        ----
-        That will return a xref:types-cluster_feature[ClusterFeature] object containing the name:
-        [source,xml]
-        ----
+        ```
+        That will return a `ovirtsdk4.types.ClusterFeature` object containing the name:
+
+        ```xml
         <cluster_feature id="456">
           <name>libgfapi_supported</name>
         </cluster_feature>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4826,10 +5018,10 @@ class ClusterEnabledFeatureService(Service):
         """
         Disables a cluster feature.
         For example, to disable the feature `456` of cluster `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/clusters/123/enabledfeatures/456
-        ----
+        ```
 
 
         """
@@ -4877,17 +5069,15 @@ class ClusterEnabledFeaturesService(Service):
         """
         Enable an additional feature for a cluster.
         For example, to enable a feature `456` on cluster `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/123/enabledfeatures
-        ----
+        ```
         The request body should look like this:
-        [source,xml]
-        ----
+
+        ```xml
         <cluster_feature id="456"/>
-        ----
-
-
+        ```
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -4911,32 +5101,36 @@ class ClusterEnabledFeaturesService(Service):
         """
         Lists the additional features enabled for the cluster.
         For example, to get the features enabled for cluster `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusters/123/enabledfeatures
-        ----
+        ```
         This will return a list of features:
-        [source,xml]
-        ----
+
+        ```xml
         <enabled_features>
           <cluster_feature id="123">
              <name>test_feature</name>
           </cluster_feature>
           ...
         </enabled_features>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5001,14 +5195,18 @@ class ClusterExternalProvidersService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5055,29 +5253,33 @@ class ClusterFeatureService(Service):
         """
         Provides the information about the a cluster feature supported by a cluster level.
         For example, to find details of the cluster feature `456` for cluster level 4.1, send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusterlevels/4.1/clusterfeatures/456
-        ----
-        That will return a xref:types-cluster_feature[ClusterFeature] object containing the name:
-        [source,xml]
-        ----
+        ```
+        That will return a `ovirtsdk4.types.ClusterFeature` object containing the name:
+
+        ```xml
         <cluster_feature id="456">
           <name>libgfapi_supported</name>
         </cluster_feature>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5124,32 +5326,36 @@ class ClusterFeaturesService(Service):
     ):
         """
         Lists the cluster features supported by the cluster level.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusterlevels/4.1/clusterfeatures
-        ----
+        ```
         This will return a list of cluster features supported by the cluster level:
-        [source,xml]
-        ----
+
+        ```xml
         <cluster_features>
           <cluster_feature id="123">
              <name>test_feature</name>
           </cluster_feature>
           ...
         </cluster_features>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5191,9 +5397,8 @@ class ClusterFeaturesService(Service):
 
 class ClusterLevelService(Service):
     """
-    Provides information about a specific cluster level. See the xref:services-cluster_levels[ClusterLevels] service for
+    Provides information about a specific cluster level. See the `ClusterLevelsService` service for
     more information.
-
     """
 
     def __init__(self, connection, path):
@@ -5211,14 +5416,14 @@ class ClusterLevelService(Service):
         """
         Provides the information about the capabilities of the specific cluster level managed by this service.
         For example, to find what CPU types are supported by level 3.6 you can send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusterlevels/3.6
-        ----
-        That will return a xref:types-cluster_level[ClusterLevel] object containing the supported CPU types, and other
+        ```
+        That will return a `ovirtsdk4.types.ClusterLevel` object containing the supported CPU types, and other
         information which describes the cluster level:
-        [source,xml]
-        ----
+
+        ```xml
         <cluster_level id="3.6">
           <cpu_types>
             <cpu_type>
@@ -5236,19 +5441,23 @@ class ClusterLevelService(Service):
             ...
           </permits>
         </cluster_level>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5308,33 +5517,37 @@ class ClusterLevelsService(Service):
     ):
         """
         Lists the cluster levels supported by the system.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusterlevels
-        ----
+        ```
         This will return a list of available cluster levels.
-        [source,xml]
-        ----
+
+        ```xml
         <cluster_levels>
           <cluster_level id="4.0">
              ...
           </cluster_level>
           ...
         </cluster_levels>
-        ----
+        ```
         The order of the returned cluster levels isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5397,14 +5610,18 @@ class ClusterNetworkService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5455,13 +5672,17 @@ class ClusterNetworkService(Service):
 
         This method supports the following parameters:
 
-        `network`:: The cluster network.
+        `network` \n
+        The cluster network.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5507,26 +5728,30 @@ class ClusterNetworksService(Service):
         """
         Assigns the network to a cluster.
         Post a request like in the example below to assign the network to a cluster:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/123/networks
-        ----
+        ```
         Use the following example in its body:
-        [source,xml]
-        ----
+
+        ```xml
         <network id="123" />
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `network`:: The network object to be assigned to the cluster.
+        `network` \n
+        The network object to be assigned to the cluster.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5555,16 +5780,21 @@ class ClusterNetworksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of networks to return. If not specified, all the networks are returned.
+        `max` \n
+        Sets the maximum number of networks to return. If not specified, all the networks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5630,13 +5860,13 @@ class ClustersService(Service):
         Creates a new cluster.
         This requires the `name`, `cpu.type`, and `data_center` attributes. Identify the data center with either the `id`
         or `name` attribute.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```xml
         <cluster>
           <name>mycluster</name>
           <cpu>
@@ -5644,16 +5874,16 @@ class ClustersService(Service):
           </cpu>
           <data_center id="123"/>
         </cluster>
-        ----
+        ```
         To create a cluster with an external network provider to be deployed on
         every host that is added to the cluster, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters
-        ----
+        ```
         With a request body containing a reference to the desired provider:
-        [source,xml]
-        ----
+
+        ```xml
         <cluster>
           <name>mycluster</name>
           <cpu>
@@ -5664,7 +5894,7 @@ class ClustersService(Service):
             <external_provider name="ovirt-provider-ovn"/>
           </external_network_providers>
         </cluster>
-        ----
+        ```
 
 
         """
@@ -5699,24 +5929,32 @@ class ClustersService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of clusters to return. If not specified, all the clusters are returned.
+        `max` \n
+        Sets the maximum number of clusters to return. If not specified, all the clusters are returned.
 
-        `search`:: A query string used to restrict the returned clusters.
+        `search` \n
+        A query string used to restrict the returned clusters.
 
-        `case_sensitive`:: Indicates if the search should be performed taking case into account.
+        `case_sensitive` \n
+        Indicates if the search should be performed taking case into account.
         The default value is `true`, which means that case is taken into account. To search
         ignoring case, set it to `false`.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5789,13 +6027,17 @@ class CopyableService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the copy should be performed asynchronously.
+        `async_` \n
+        Indicates if the copy should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5845,14 +6087,18 @@ class CpuProfileService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5878,13 +6124,17 @@ class CpuProfileService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -5915,8 +6165,6 @@ class CpuProfileService(Service):
     ):
         """
         Update the specified cpu profile in the system.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6006,16 +6254,21 @@ class CpuProfilesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of profiles to return. If not specified, all the profiles are returned.
+        `max` \n
+        Sets the maximum number of profiles to return. If not specified, all the profiles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6086,26 +6339,30 @@ class DataCenterService(Service):
         switch to another host if the SPM has uncleared tasks.
         Clearing all finished tasks enables the SPM switching.
         For example, to clean all the finished tasks on a data center with ID `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/cleanfinishedtasks
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6136,12 +6393,12 @@ class DataCenterService(Service):
         """
         Get a data center.
         An example of getting a data center:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/datacenters/123
-        ----
-        [source,xml]
-        ----
+        ```
+
+        ```xml
         <data_center href="/ovirt-engine/api/datacenters/123" id="123">
           <name>Default</name>
           <description>The default Data Center</description>
@@ -6168,21 +6425,26 @@ class DataCenterService(Service):
           </version>
           <mac_pool href="/ovirt-engine/api/macpools/456" id="456"/>
         </data_center>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6212,10 +6474,10 @@ class DataCenterService(Service):
     ):
         """
         Removes the data center.
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/datacenters/123
-        ----
+        ```
         Without any special parameters, the storage domains attached to the data center are detached and then removed
         from the storage. If something fails when performing this operation, for example if there is no host available to
         remove the storage domains from the storage, the complete operation will fail.
@@ -6226,17 +6488,22 @@ class DataCenterService(Service):
 
         This method supports the following parameters:
 
-        `force`:: Indicates if the operation should succeed, and the storage domain removed from the database, even if
+        `force` \n
+        Indicates if the operation should succeed, and the storage domain removed from the database, even if
         something fails during the operation.
         This parameter is optional, and the default value is `false`.
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6273,31 +6540,36 @@ class DataCenterService(Service):
         Used for manually setting a storage domain in the data center as a master.
         For example, for setting a storage domain with ID '456' as a master on a data center with ID '123',
         send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/setmaster
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```xml
         <action>
           <storage_domain id="456"/>
         </action>
-        ----
+        ```
         The new master storage domain can be also specified by its name.
 
 
         This method supports the following parameters:
 
-        `storage_domain`:: The new master storage domain for the data center.
+        `storage_domain` \n
+        The new master storage domain for the data center.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6331,29 +6603,33 @@ class DataCenterService(Service):
         Updates the data center.
         The `name`, `description`, `storage_type`, `version`, `storage_format` and `mac_pool` elements are updatable
         post-creation. For example, to change the name and description of data center `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/datacenters/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```xml
         <data_center>
           <name>myupdatedname</name>
           <description>An updated description for the data center</description>
         </data_center>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `data_center`:: The data center that is being updated.
+        `data_center` \n
+        The data center that is being updated.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6418,22 +6694,22 @@ class DataCenterService(Service):
         """
         Attach and detach storage domains to and from a data center.
         For attaching a single storage domain we should use the following POST request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/storagedomains
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```xml
         <storage_domain>
           <name>data1</name>
         </storage_domain>
-        ----
+        ```
         For detaching a single storage domain we should use the following DELETE request:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/datacenters/123/storagedomains/123
-        ----
+        ```
 
         """
         return AttachedStorageDomainsService(self._connection, '%s/storagedomains' % self._path)
@@ -6501,14 +6777,18 @@ class DataCenterNetworkService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6559,13 +6839,17 @@ class DataCenterNetworkService(Service):
 
         This method supports the following parameters:
 
-        `network`:: The data center network.
+        `network` \n
+        The data center network.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6611,28 +6895,32 @@ class DataCenterNetworksService(Service):
         """
         Create a new network in a data center.
         Post a request like in the example below to create a new network in a data center with an ID of `123`.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/networks
-        ----
+        ```
         Use the following example in its body:
-        [source,xml]
-        ----
+
+        ```xml
         <network>
           <name>mynetwork</name>
         </network>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `network`:: The network object to be created in the data center.
+        `network` \n
+        The network object to be created in the data center.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6661,16 +6949,21 @@ class DataCenterNetworksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of networks to return. If not specified, all the networks are returned.
+        `max` \n
+        Sets the maximum number of networks to return. If not specified, all the networks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6736,29 +7029,33 @@ class DataCentersService(Service):
         Creates a new data center.
         Creation of a new data center requires the `name` and `local` elements. For example, to create a data center
         named `mydc` that uses shared storage (NFS, iSCSI or fibre channel) send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+
+        ```xml
         <data_center>
           <name>mydc</name>
           <local>false</local>
         </data_center>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `data_center`:: The data center that is being added.
+        `data_center` \n
+        The data center that is being added.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6786,13 +7083,13 @@ class DataCentersService(Service):
         """
         Lists the data centers.
         The following request retrieves a representation of the data centers:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/datacenters
-        ----
+        ```
         The above request performed with `curl`:
-        [source,bash]
-        ----
+
+        ```bash
         curl \
         --request GET \
         --cacert /etc/pki/ovirt-engine/ca.pem \
@@ -6800,10 +7097,10 @@ class DataCentersService(Service):
         --header "Accept: application/xml" \
         --user "admin@internal:mypassword" \
         https://myengine.example.com/ovirt-engine/api/datacenters
-        ----
+        ```
         This is what an example response could look like:
-        [source,xml]
-        ----
+
+        ```xml
         <data_center href="/ovirt-engine/api/datacenters/123" id="123">
           <name>Default</name>
           <description>The default Data Center</description>
@@ -6828,7 +7125,7 @@ class DataCentersService(Service):
             <minor>0</minor>
           </version>
         </data_center>
-        ----
+        ```
         Note the `id` code of your `Default` data center. This code identifies this data center in relation to other
         resources of your virtual environment.
         The data center also contains a link to the storage domains collection. The data center uses this collection to
@@ -6839,24 +7136,32 @@ class DataCentersService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of data centers to return. If not specified all the data centers are returned.
+        `max` \n
+        Sets the maximum number of data centers to return. If not specified all the data centers are returned.
 
-        `search`:: A query string used to restrict the returned data centers.
+        `search` \n
+        A query string used to restrict the returned data centers.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6931,12 +7236,12 @@ class DiskAttachmentService(Service):
         """
         Returns the details of the attachment, including the bootable flag and link to the disk.
         An example of getting a disk attachment:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/vms/123/diskattachments/456
-        ----
-        [source,xml]
-        ----
+        ```
+
+        ```xml
         <disk_attachment href="/ovirt-engine/api/vms/123/diskattachments/456" id="456">
           <active>true</active>
           <bootable>true</bootable>
@@ -6944,19 +7249,23 @@ class DiskAttachmentService(Service):
           <disk href="/ovirt-engine/api/disks/456" id="456"/>
           <vm href="/ovirt-engine/api/vms/123" id="123"/>
         </disk_attachment>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -6984,22 +7293,26 @@ class DiskAttachmentService(Service):
         This will only detach the disk from the virtual machine, but won't remove it from
         the system, unless the `detach_only` parameter is `false`.
         An example of removing a disk attachment:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/vms/123/diskattachments/456?detach_only=true
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `detach_only`:: Indicates if the disk should only be detached from the virtual machine, but not removed from the system.
+        `detach_only` \n
+        Indicates if the disk should only be detached from the virtual machine, but not removed from the system.
         The default value is `true`, which won't remove the disk from the system.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7025,8 +7338,8 @@ class DiskAttachmentService(Service):
     ):
         """
         Update the disk attachment and the disk properties within it.
-        [source]
-        ----
+        
+        ```
         PUT /vms/{vm:id}/disksattachments/{attachment:id}
         <disk_attachment>
           <bootable>true</bootable>
@@ -7038,7 +7351,7 @@ class DiskAttachmentService(Service):
             ...
           </disk>
         </disk_attachment>
-        ----
+        ```
 
 
         """
@@ -7068,9 +7381,7 @@ class DiskAttachmentService(Service):
 class DiskAttachmentsService(Service):
     """
     This service manages the set of disks attached to a virtual machine. Each attached disk is represented by a
-    xref:types-disk_attachment[DiskAttachment], containing the bootable flag, the disk interface and the reference to
-    the disk.
-
+    `DiskAttachment`, containing the bootable flag, the disk interface and the reference to the disk.
     """
 
     def __init__(self, connection, path):
@@ -7088,8 +7399,8 @@ class DiskAttachmentsService(Service):
         """
         Adds a new disk attachment to the virtual machine. The `attachment` parameter can contain just a reference, if
         the disk already exists:
-        [source,xml]
-        ----
+
+        ```xml
         <disk_attachment>
           <bootable>true</bootable>
           <pass_discard>true</pass_discard>
@@ -7097,10 +7408,10 @@ class DiskAttachmentsService(Service):
           <active>true</active>
           <disk id="123"/>
         </disk_attachment>
-        ----
+        ```
         Or it can contain the complete representation of the disk, if the disk doesn't exist yet:
-        [source,xml]
-        ----
+
+        ```xml
         <disk_attachment>
           <bootable>true</bootable>
           <pass_discard>true</pass_discard>
@@ -7112,13 +7423,13 @@ class DiskAttachmentsService(Service):
             ...
           </disk>
         </disk_attachment>
-        ----
+        ```
         In this case the disk will be created and then attached to the virtual machine.
         In both cases, use the following URL for a virtual machine with an id `345`:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/345/diskattachments
-        ----
+        ```
         IMPORTANT: The server accepts requests that do not contain the `active` attribute, but the effect is
         undefined. In some cases the disk will be automatically activated and in other cases it won't. To
         avoid issues it is strongly recommended to always include the `active` attribute with the desired
@@ -7127,13 +7438,17 @@ class DiskAttachmentsService(Service):
 
         This method supports the following parameters:
 
-        `attachment`:: The disk attachment to add to the virtual machine.
+        `attachment` \n
+        The disk attachment to add to the virtual machine.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7161,14 +7476,18 @@ class DiskAttachmentsService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7194,13 +7513,17 @@ class DiskAttachmentsService(Service):
         """
         This method supports the following parameters:
 
-        `attachment`:: The disk attachment to add to the virtual machine.
+        `attachment` \n
+        The disk attachment to add to the virtual machine.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7224,13 +7547,17 @@ class DiskAttachmentsService(Service):
         """
         This method supports the following parameters:
 
-        `attachment`:: The disk attachment to add to the virtual machine.
+        `attachment` \n
+        The disk attachment to add to the virtual machine.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7287,14 +7614,18 @@ class DiskProfileService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7320,13 +7651,17 @@ class DiskProfileService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7448,16 +7783,21 @@ class DiskProfilesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of profiles to return. If not specified all the profiles are returned.
+        `max` \n
+        Sets the maximum number of profiles to return. If not specified all the profiles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7517,14 +7857,18 @@ class DiskSnapshotService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7550,13 +7894,17 @@ class DiskSnapshotService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7616,20 +7964,27 @@ class DiskSnapshotsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of snapshots to return. If not specified all the snapshots are returned.
+        `max` \n
+        Sets the maximum number of snapshots to return. If not specified all the snapshots are returned.
 
-        `include_active`:: If true return also active snapshots. If not specified active snapshots are not returned.
+        `include_active` \n
+        If true return also active snapshots. If not specified active snapshots are not returned.
 
-        `include_template`:: If true return also template snapshots. If not specified template snapshots are not returned.
+        `include_template` \n
+        If true return also template snapshots. If not specified template snapshots are not returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7700,22 +8055,21 @@ class DisksService(Service):
         """
         Adds a new floating disk.
         There are three types of disks that can be added - disk image, direct LUN and Managed Block disk.
-        link:https://wiki.openstack.org/wiki/Cinder[Cinder] integration has been replaced by Managed Block Storage.
+        link:https://wiki.openstack.org/wiki/Cinder integration has been replaced by Managed Block Storage.
         *Adding a new image disk:*
-        When creating a new floating image xref:types-disk[Disk], the API requires the `storage_domain`, `provisioned_size`
+        When creating a new floating image, the API requires the `storage_domain`, `provisioned_size`
         and `format` attributes.
-        Note that block storage domains (i.e. storage domains with the xref:types-storage_type[storage type] of iSCSI or
-        FCP) do not support the combination of the raw `format` with `sparse=true`, so `sparse=false` must be stated
-        explicitly.
+        Note that block storage domains (i.e. storage domains with the `StorageType` of iSCSI or FCP)
+        do not support the combination of the raw `format` with `sparse=true`, so `sparse=false` must be stated explicitly.
         To create a new floating image disk with specified `provisioned_size`, `format` and `name` on a storage domain
         with an id `123` and enabled for incremental backup, send a request as follows:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/disks
-        ----
+        ```
         With a request body as follows:
-        [source,xml]
-        ----
+
+        ```xml
         <disk>
           <storage_domains>
             <storage_domain id="123"/>
@@ -7725,7 +8079,7 @@ class DisksService(Service):
           <format>cow</format>
           <backup>incremental</backup>
         </disk>
-        ----
+        ```
         *Adding a new direct LUN disk:*
         When adding a new floating direct LUN via the API, there are two flavors that can be used:
         . With a `host` element - in this case, the host is used for sanity checks (e.g., that the LUN is visible) and
@@ -7735,13 +8089,13 @@ class DisksService(Service):
         To create a new floating direct LUN disk with a `host` element with an id `123`, specified `alias`, `type` and
         `logical_unit` with an id `456` (that has the attributes `address`, `port` and `target`),
         send a request as follows:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/disks
-        ----
+        ```
         With a request body as follows:
-        [source,xml]
-        ----
+
+        ```xml
         <disk>
           <alias>mylun</alias>
           <lun_storage>
@@ -7756,11 +8110,10 @@ class DisksService(Service):
             </logical_units>
           </lun_storage>
         </disk>
-        ----
+        ```
         To create a new floating direct LUN disk without using a host, remove the `host` element.
         *Adding a new Cinder disk:*
         Cinder integration has been replaced by Managed Block Storage.
-        //TODO: Add an example for adding an MBS disk
         *Adding a floating disks in order to upload disk snapshots:*
         Since version 4.2 of the engine it is possible to upload disks with
         snapshots. This request should be used to create the base image of the
@@ -7771,8 +8124,7 @@ class DisksService(Service):
         backup process. The image identifier can be also fetched using the
         `qemu-img info` command. For example, if the disk image is stored into
         a file named `b7a4c6c5-443b-47c5-967f-6abc79675e8b/myimage.img`:
-        [source,shell]
-        ----
+        ```shell
         $ qemu-img info b7a4c6c5-443b-47c5-967f-6abc79675e8b/myimage.img
         image: b548366b-fb51-4b41-97be-733c887fe305
         file format: qcow2
@@ -7781,16 +8133,16 @@ class DisksService(Service):
         cluster_size: 65536
         backing file: ad58716a-1fe9-481f-815e-664de1df04eb
         backing file format: raw
-        ----
+        ```
         To create a disk with with the disk identifier and image identifier obtained
         with the `qemu-img info` command shown above, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/disks
-        ----
+        ```
         With a request body as follows:
-        [source,xml]
-        ----
+        ]
+        ```xml
         <disk id="b7a4c6c5-443b-47c5-967f-6abc79675e8b">
           <image_id>b548366b-fb51-4b41-97be-733c887fe305</image_id>
           <storage_domains>
@@ -7800,18 +8152,22 @@ class DisksService(Service):
           <provisioned_size>1048576</provisioned_size>
           <format>cow</format>
         </disk>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `disk`:: The disk.
+        `disk` \n
+        The disk.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7837,13 +8193,13 @@ class DisksService(Service):
     ):
         """
         Get list of disks.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/disks
-        ----
+        ```
         You will get a XML response which will look like this one:
-        [source,xml]
-        ----
+
+        ```xml
         <disks>
           <disk id="123">
             <actions>...</actions>
@@ -7863,29 +8219,35 @@ class DisksService(Service):
           </disk>
           ...
         </disks>
-        ----
+        ```
         The order of the returned list of disks is guaranteed only if the `sortby` clause is included in the
         `search` parameter.
 
-
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of disks to return. If not specified all the disks are returned.
+        `max` \n
+        Sets the maximum number of disks to return. If not specified all the disks are returned.
 
-        `search`:: A query string used to restrict the returned disks.
+        `search` \n
+        A query string used to restrict the returned disks.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7925,13 +8287,17 @@ class DisksService(Service):
 
         This method supports the following parameters:
 
-        `disk`:: The disk.
+        `disk` \n
+        The disk.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -7958,13 +8324,17 @@ class DisksService(Service):
 
         This method supports the following parameters:
 
-        `disk`:: The disk.
+        `disk` \n
+        The disk.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8024,12 +8394,12 @@ class DomainService(Service):
         """
         Gets the authentication domain information.
         Usage:
-        ....
+        ```
         GET /ovirt-engine/api/domains/5678
-        ....
+        ```
         Will return the domain information:
-        [source,xml]
-        ----
+
+        ```xml
         <domain href="/ovirt-engine/api/domains/5678" id="5678">
           <name>internal-authz</name>
           <link href="/ovirt-engine/api/domains/5678/users" rel="users"/>
@@ -8037,19 +8407,23 @@ class DomainService(Service):
           <link href="/ovirt-engine/api/domains/5678/users?search={query}" rel="users/search"/>
           <link href="/ovirt-engine/api/domains/5678/groups?search={query}" rel="groups/search"/>
         </domain>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8116,14 +8490,18 @@ class DomainGroupService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8176,22 +8554,29 @@ class DomainGroupsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of groups to return. If not specified all the groups are returned.
+        `max` \n
+        Sets the maximum number of groups to return. If not specified all the groups are returned.
 
-        `search`:: A query string used to restrict the returned groups.
+        `search` \n
+        A query string used to restrict the returned groups.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8260,12 +8645,12 @@ class DomainUserService(Service):
         """
         Gets the domain user information.
         Usage:
-        ....
+        ```
         GET /ovirt-engine/api/domains/5678/users/1234
-        ....
+        ```
         Will return the domain user information:
-        [source,xml]
-        ----
+        ]
+        ```xml
         <user href="/ovirt-engine/api/users/1234" id="1234">
           <name>admin</name>
           <namespace>*</namespace>
@@ -8276,19 +8661,23 @@ class DomainUserService(Service):
           </domain>
           <groups/>
         </user>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8338,14 +8727,18 @@ class DomainUserGroupsService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8396,12 +8789,12 @@ class DomainUsersService(Service):
         """
         List all the users in the domain.
         Usage:
-        ....
+        ```
         GET /ovirt-engine/api/domains/5678/users
-        ....
+        ```
         Will return the list of users in the domain:
-        [source,xml]
-        ----
+        ]
+        ```xml
         <users>
           <user href="/ovirt-engine/api/domains/5678/users/1234" id="1234">
             <name>admin</name>
@@ -8414,28 +8807,35 @@ class DomainUsersService(Service):
             <groups/>
           </user>
         </users>
-        ----
+        ```
         The order of the returned list of users isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of users to return. If not specified all the users are returned.
+        `max` \n
+        Sets the maximum number of users to return. If not specified all the users are returned.
 
-        `search`:: A query string used to restrict the returned users.
+        `search` \n
+        A query string used to restrict the returned users.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8508,12 +8908,12 @@ class DomainsService(Service):
         """
         List all the authentication domains in the system.
         Usage:
-        ....
+        ```
         GET /ovirt-engine/api/domains
-        ....
+        ```
         Will return the list of domains:
-        [source,xml]
-        ----
+        
+        ```xml
         <domains>
           <domain href="/ovirt-engine/api/domains/5678" id="5678">
             <name>internal-authz</name>
@@ -8523,22 +8923,27 @@ class DomainsService(Service):
             <link href="/ovirt-engine/api/domains/5678/groups?search={query}" rel="groups/search"/>
           </domain>
         </domains>
-        ----
+        ```
         The order of the returned list of domains isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of domains to return. If not specified all the domains are returned.
+        `max` \n
+        Sets the maximum number of domains to return. If not specified all the domains are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8602,12 +9007,12 @@ class EventService(Service):
         """
         Get an event.
         An example of getting an event:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/events/123
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <event href="/ovirt-engine/api/events/123" id="123">
           <description>Host example.com was added by admin@internal-authz.</description>
           <code>42</code>
@@ -8621,7 +9026,7 @@ class EventService(Service):
           <host href="/ovirt-engine/api/hosts/789" id="789"/>
           <user href="/ovirt-engine/api/users/987" id="987"/>
         </event>
-        ----
+        ```
         Note that the number of fields changes according to the information that resides on the event.
         For example, for storage domain related events you will get the storage domain reference,
         as well as the reference for the data center this storage domain resides in.
@@ -8629,14 +9034,18 @@ class EventService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8662,21 +9071,25 @@ class EventService(Service):
         """
         Removes an event from internal audit log.
         An event can be removed by sending following request
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/events/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8728,18 +9141,18 @@ class EventSubscriptionService(Service):
         Gets the information about the event-subscription.
         For example to retrieve the information about the subscription of user '123' to
         the event 'vm_console_detected':
-        ....
+        ```
         GET /ovirt-engine/api/users/123/vm_console_detected
-        ....
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <event-subscription href="/ovirt-engine/api/users/123/event-subscriptions/vm_console_detected">
           <event>vm_console_detected</event>
           <notification_method>smtp</notification_method>
           <user href="/ovirt-engine/api/users/123" id="123"/>
           <address>a@b.com</address>
         </event-subscription>
-        ----
+        ```
 
 
         """
@@ -8764,20 +9177,23 @@ class EventSubscriptionService(Service):
         """
         Removes the event-subscription from the system.
         For example to remove user 123's subscription to `vm_console_detected` event:
-        ....
+        ```
         DELETE /ovirt-engine/api/users/123/vm_console_detected
-        ....
-
+        ```
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8832,17 +9248,17 @@ class EventSubscriptionsService(Service):
         An event-subscription is always added in the context of a user. For example, to add new
         event-subscription for `host_high_cpu_use` for user `123`, and have the notification
         sent to the e-mail address: `a@b.com`, send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/users/123/eventsubscriptions
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <event_subscription>
             <event>host_high_cpu_use</event>
             <address>a@b.com</address>
         </event_subscription>
-        ----
+        ```
         The event name will become the ID of the new event-subscription entity:
         GET .../api/users/123/eventsubscriptions/host_high_cpu_use
         Note that no user id is provided in the request body. This is because the user-id (in this case 123)
@@ -8853,13 +9269,17 @@ class EventSubscriptionsService(Service):
 
         This method supports the following parameters:
 
-        `event_subscription`:: The added event-subscription.
+        `event_subscription` \n
+        The added event-subscription.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8884,11 +9304,11 @@ class EventSubscriptionsService(Service):
         """
         List the event-subscriptions for the provided user.
         For example to list event-subscriptions for user `123`:
-        ....
+        ```
         GET /ovirt-engine/api/users/123/event-subscriptions
-        ....
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <event-subscriptions>
           <event-subscription href="/ovirt-engine/api/users/123/event-subscriptions/host_install_failed">
             <event>host_install_failed</event>
@@ -8903,22 +9323,27 @@ class EventSubscriptionsService(Service):
             <address>a@b.com</address>
           </event-subscription>
         </event-subscriptions>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of event-subscriptions to return.
+        `max` \n
+        Sets the maximum number of event-subscriptions to return.
         If not specified all the event-subscriptions are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -8986,8 +9411,8 @@ class EventsService(Service):
         administrator of the system. For example, an external monitoring tool may be able to detect that a file system
         is full inside the guest operating system of a virtual machine. This event can be added to the internal audit
         log sending a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/events
         <event>
           <description>File system /home is full</description>
@@ -8995,11 +9420,11 @@ class EventsService(Service):
           <origin>mymonitor</origin>
           <custom_id>1467879754</custom_id>
         </event>
-        ----
+        ```
         Events can also be linked to specific objects. For example, the above event could be linked to the specific
         virtual machine where it happened, using the `vm` link:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/events
         <event>
           <description>File system /home is full</description>
@@ -9008,7 +9433,7 @@ class EventsService(Service):
           <custom_id>1467879754</custom_id>
           <vm id="aae98225-5b73-490d-a252-899209af17e9"/>
         </event>
-        ----
+        ```
         NOTE: When using links, like the `vm` in the previous example, only the `id` attribute is accepted. The `name`
         attribute, if provided, is simply ignored.
 
@@ -9039,13 +9464,13 @@ class EventsService(Service):
     ):
         """
         Get list of events.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/events
-        ----
+        ```
         To the above request we get following response:
-        [source,xml]
-        ----
+        
+        ```xml
         <events>
           <event href="/ovirt-engine/api/events/2" id="2">
             <description>User admin@internal-authz logged out.</description>
@@ -9070,7 +9495,7 @@ class EventsService(Service):
             <user href="/ovirt-engine/api/users/57d91d48-00da-0137-0138-000000000244" id="57d91d48-00da-0137-0138-000000000244"/>
           </event>
         </events>
-        ----
+        ```
         The following events occur:
         * id="1" - The API logs in the admin user account.
         * id="2" - The API logs out of the admin user account.
@@ -9078,35 +9503,38 @@ class EventsService(Service):
         `search` parameter, then the events will be ordered according to that clause. If the `sortby` clause isn't
         included, then the events will be sorted by the numeric value of the `id` attribute, starting with the
         highest value. This, combined with the `max` parameter, simplifies obtaining the most recent event:
-        ....
+        ```
         GET /ovirt-engine/api/events?max=1
-        ....
+        ```
 
 
         This method supports the following parameters:
 
-        `from_`:: Indicates the event index after which events should be returned. The indexes of events are
+        `from_` \n
+        Indicates the event index after which events should be returned. The indexes of events are
         strictly increasing, so when this parameter is used only the events with greater indexes
         will be returned. For example, the following request will return only the events
         with indexes greater than `123`:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/events?from=123
-        ----
+        ```
         This parameter is optional, and if not specified then the first event returned will be most recently
         generated.
 
-        `max`:: Sets the maximum number of events to return. If not specified all the events are returned.
+        `max` \n
+        Sets the maximum number of events to return. If not specified all the events are returned.
 
-        `search`:: The events service provides search queries similar to other resource services.
+        `search` \n
+        The events service provides search queries similar to other resource services.
         We can search by providing specific severity.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/events?search=severity%3Dnormal
-        ----
+        ```
         To the above request we get a list of events which severity is equal to `normal`:
-        [source,xml]
-        ----
+        
+        ```xml
         <events>
           <event href="/ovirt-engine/api/events/2" id="2">
             <description>User admin@internal-authz logged out.</description>
@@ -9129,40 +9557,45 @@ class EventsService(Service):
             <time>2016-09-14T11:52:18.861+02:00</time>
           </event>
         </events>
-        ----
+        ```
         A virtualization environment generates a large amount of events after
         a period of time. However, the API only displays a default number of
         events for one search query. To display more than the default, the API
         separates results into pages with the page command in a search query.
         The following search query tells the API to paginate results using a
         page value in combination with the sortby clause:
-        [source]
-        ----
+        
+        ```
         sortby time asc page 1
-        ----
+        ```
         Below example paginates event resources. The URL-encoded request is:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/events?search=sortby%20time%20asc%20page%201
-        ----
+        ```
         Increase the page value to view the next page of results.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/events?search=sortby%20time%20asc%20page%202
-        ----
+        ```
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9203,13 +9636,17 @@ class EventsService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the un-delete should be performed asynchronously.
+        `async_` \n
+        Indicates if the un-delete should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9276,12 +9713,12 @@ class ExternalComputeResourceService(Service):
         """
         Retrieves external compute resource details.
         For example, to get the details of compute resource `234` of provider `123`, send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/externalhostproviders/123/computeresources/234
-        ....
+        ```
         It will return a response like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <external_compute_resource href="/ovirt-engine/api/externalhostproviders/123/computeresources/234" id="234">
           <name>hostname</name>
           <provider>oVirt</provider>
@@ -9289,19 +9726,23 @@ class ExternalComputeResourceService(Service):
           <user>admin@internal</user>
           <external_host_provider href="/ovirt-engine/api/externalhostproviders/123" id="123"/>
         </external_compute_resource>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9353,12 +9794,12 @@ class ExternalComputeResourcesService(Service):
         """
         Retrieves a list of external compute resources.
         For example, to retrieve the compute resources of external host provider `123`, send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/externalhostproviders/123/computeresources
-        ....
+        ```
         It will return a response like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <external_compute_resources>
           <external_compute_resource href="/ovirt-engine/api/externalhostproviders/123/computeresources/234" id="234">
             <name>hostname</name>
@@ -9369,22 +9810,27 @@ class ExternalComputeResourcesService(Service):
            </external_compute_resource>
            ...
         </external_compute_resources>
-        ----
+        ```
         The order of the returned list of compute resources isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of resources to return. If not specified all the resources are returned.
+        `max` \n
+        Sets the maximum number of resources to return. If not specified all the resources are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9450,12 +9896,12 @@ class ExternalDiscoveredHostService(Service):
         Retrieves information about an host that is managed in external provider management system, such as Foreman. The
         information includes hostname, address, subnet, base image and more.
         For example, to get the details of host `234` from provider `123`, send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/externalhostproviders/123/discoveredhosts/234
-        ....
+        ```
         The result will be like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <external_discovered_host href="/ovirt-engine/api/externalhostproviders/123/discoveredhosts/234" id="234">
          <name>mac001a4ad04040</name>
          <ip>10.34.67.43</ip>
@@ -9464,19 +9910,23 @@ class ExternalDiscoveredHostService(Service):
          <subnet_name>sat0</subnet_name>
          <external_host_provider href="/ovirt-engine/api/externalhostproviders/123" id="123"/>
         </external_discovered_host>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9526,12 +9976,12 @@ class ExternalDiscoveredHostsService(Service):
         Get list of discovered hosts' information.
         Discovered hosts are fetched from third-party providers such as Foreman.
         To list all discovered hosts for provider `123` send the following:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/externalhostproviders/123/discoveredhost
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <external_discovered_hosts>
          <external_discovered_host href="/ovirt-engine/api/externalhostproviders/123/discoveredhosts/456" id="456">
           <name>mac001a4ad04031</name>
@@ -9551,22 +10001,27 @@ class ExternalDiscoveredHostsService(Service):
          </external_discovered_host>
          ...
         </external_discovered_hosts>
-        ----
+        ```
         The order of the returned list of hosts isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of hosts to return. If not specified all the hosts are returned.
+        `max` \n
+        Sets the maximum number of hosts to return. If not specified all the hosts are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9626,14 +10081,18 @@ class ExternalHostService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9682,12 +10141,12 @@ class ExternalHostGroupService(Service):
         """
         Get host group information.
         For example, to get the details of hostgroup `234` of provider `123`, send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/externalhostproviders/123/hostgroups/234
-        ....
+        ```
         It will return a response like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <external_host_group href="/ovirt-engine/api/externalhostproviders/123/hostgroups/234" id="234">
           <name>rhel7</name>
           <architecture_name>x86_64</architecture_name>
@@ -9696,19 +10155,23 @@ class ExternalHostGroupService(Service):
           <subnet_name>sat0</subnet_name>
           <external_host_provider href="/ovirt-engine/api/externalhostproviders/123" id="123"/>
         </external_host_group>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9759,12 +10222,12 @@ class ExternalHostGroupsService(Service):
         Host group is a term of host providers - the host group includes provision details. This API returns all possible
         hostgroups exposed by the external provider.
         For example, to get the details of all host groups of provider `123`, send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/externalhostproviders/123/hostgroups
-        ....
+        ```
         The response will be like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <external_host_groups>
           <external_host_group href="/ovirt-engine/api/externalhostproviders/123/hostgroups/234" id="234">
             <name>rhel7</name>
@@ -9776,22 +10239,27 @@ class ExternalHostGroupsService(Service):
           </external_host_group>
           ...
         </external_host_groups>
-        ----
+        ```
         The order of the returned list of host groups isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of groups to return. If not specified all the groups are returned.
+        `max` \n
+        Sets the maximum number of groups to return. If not specified all the groups are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9884,18 +10352,24 @@ class ExternalHostProvidersService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of providers to return. If not specified all the providers are returned.
+        `max` \n
+        Sets the maximum number of providers to return. If not specified all the providers are returned.
 
-        `search`:: A query string used to restrict the returned external host providers.
+        `search` \n
+        A query string used to restrict the returned external host providers.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -9964,16 +10438,21 @@ class ExternalHostsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of hosts to return. If not specified all the hosts are returned.
+        `max` \n
+        Sets the maximum number of hosts to return. If not specified all the hosts are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10038,14 +10517,18 @@ class ExternalNetworkProviderConfigurationService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10097,14 +10580,18 @@ class ExternalNetworkProviderConfigurationsService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10189,21 +10676,25 @@ class ExternalProviderService(Service):
         """
         In order to test connectivity for external provider we need
         to run following request where 123 is an id of a provider.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/externalhostproviders/123/testconnectivity
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the test should be performed asynchronously.
+        `async_` \n
+        Indicates if the test should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10264,31 +10755,35 @@ class ExternalProviderCertificateService(Service):
     ):
         """
         Get specific certificate.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/externalhostproviders/123/certificate/0
-        ----
+        ```
         And here is sample response:
-        [source,xml]
-        ----
+        
+        ```xml
         <certificate id="0">
           <organization>provider.example.com</organization>
           <subject>CN=provider.example.com</subject>
           <content>...</content>
         </certificate>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10336,34 +10831,39 @@ class ExternalProviderCertificatesService(Service):
     ):
         """
         Returns the chain of certificates presented by the external provider.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/externalhostproviders/123/certificates
-        ----
+        ```
         And here is sample response:
-        [source,xml]
-        ----
+        
+        ```xml
         <certificates>
           <certificate id="789">...</certificate>
           ...
         </certificates>
-        ----
+        ```
         The order of the returned certificates is always guaranteed to be the sign order: the first is the
         certificate of the server itself, the second the certificate of the CA that signs the first, so on.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of certificates to return. If not specified all the certificates are returned.
+        `max` \n
+        Sets the maximum number of certificates to return. If not specified all the certificates are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10429,13 +10929,13 @@ class ExternalTemplateImportsService(Service):
         """
         This operation is used to import a template from external hypervisor.
         For example import of a template OVA can be facilitated using the following request:
-        [source]
-        ----
+        
+        ```
         POST /externaltemplateimports
-        ----
-        With request body of type xref:types-external_template_import[ExternalTemplateImport], for example:
-        [source,xml]
-        ----
+        ```
+        With request body of type `ExternalTemplateImport`, for example:
+        
+        ```xml
         <external_template_import>
           <template>
             <name>my_template</name>
@@ -10445,7 +10945,7 @@ class ExternalTemplateImportsService(Service):
           <url>ova:///mnt/ova/ova_template.ova</url>
           <host id="8bb5ade5-e988-4000-8b93-dbfc6717fe50" />
         </external_template_import>
-        ----
+        ```
 
 
         """
@@ -10492,13 +10992,13 @@ class ExternalVmImportsService(Service):
         """
         This operation is used to import a virtual machine from external hypervisor, such as KVM, XEN or VMware.
         For example import of a virtual machine from VMware can be facilitated using the following request:
-        [source]
-        ----
+        
+        ```
         POST /externalvmimports
-        ----
-        With request body of type xref:types-external_vm_import[ExternalVmImport], for example:
-        [source,xml]
-        ----
+        ```
+        With request body of type `ExternalVmImport`, for example:
+        
+        ```xml
         <external_vm_import>
           <vm>
             <name>my_vm</name>
@@ -10513,7 +11013,7 @@ class ExternalVmImportsService(Service):
           <url>vpx://wmware_user@vcenter-host/DataCenter/Cluster/esxi-host?no_verify=1</url>
           <drivers_iso id="virtio-win-1.6.7.iso" />
         </external_vm_import>
-        ----
+        ```
 
 
         """
@@ -10559,13 +11059,13 @@ class FenceAgentService(Service):
     ):
         """
         Gets details of this fence agent.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/hosts/123/fenceagents/0
-        ----
+        ```
         And here is sample response:
-        [source,xml]
-        ----
+        
+        ```xml
         <agent id="0">
           <type>apc</type>
           <order>1</order>
@@ -10575,19 +11075,23 @@ class FenceAgentService(Service):
           <port>9</port>
           <options>name1=value1, name2=value2</options>
         </agent>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10612,21 +11116,25 @@ class FenceAgentService(Service):
     ):
         """
         Removes a fence agent for a specific host.
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/hosts/123/fenceagents/0
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10661,13 +11169,17 @@ class FenceAgentService(Service):
 
         This method supports the following parameters:
 
-        `agent`:: Fence agent details.
+        `agent` \n
+        Fence agent details.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10720,17 +11232,19 @@ class FenceAgentsService(Service):
     ):
         """
         Add a new fencing-agent to the host.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts/123/fenceagents
+        ```
         You should consult the /usr/sbin/fence_<agent_name> manual page for
         the legal parameters to [name1=value1, name2=value2,...] in the options field.
         If any parameter in options appears by name that means that it is mandatory.
         For example in <options>slot=7[,name1=value1, name2=value2,...]</options>
         slot is mandatory.
-        ----
+
         apc, bladecenter, wti fencing agent/s sample request:
-        [source,xml]
+        
+        ```xml
           <agent>
             <type>apc</type>
             <order>1</order>
@@ -10740,8 +11254,10 @@ class FenceAgentsService(Service):
             <port>9</port>
             <options>slot=7[,name1=value1, name2=value2,...]</options>
           </agent>
+        ```
         apc_snmp, hpblade, ilo, ilo2, ilo_ssh, redfish, rsa fencing agent/s sample request:
-        [source,xml]
+        
+        ```xml
           <agent>
             <type>apc_snmp</type>
             <order>1</order>
@@ -10751,8 +11267,10 @@ class FenceAgentsService(Service):
             <port>9</port>
             <options>[name1=value1, name2=value2,...]</options>
           </agent>
+        ```
         cisco_ucs, drac5, eps fencing agent/s sample request:
-        [source,xml]
+        
+        ```xml
           <agent>
             <type>cisco_ucs</type>
             <order>1</order>
@@ -10761,8 +11279,10 @@ class FenceAgentsService(Service):
             <password>xxx</password>
             <options>slot=7[,name1=value1, name2=value2,...]</options>
           </agent>
+        ```
         drac7, ilo3, ilo4, ipmilan, rsb fencing agent/s sample request:
-        [source,xml]
+        
+        ```xml
           <agent>
             <type>drac7</type>
             <order>1</order>
@@ -10771,8 +11291,7 @@ class FenceAgentsService(Service):
             <password>xxx</password>
             <options>[name1=value1, name2=value2,...]</options>
           </agent>
-
-
+        ```
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10796,13 +11315,13 @@ class FenceAgentsService(Service):
     ):
         """
         Returns the list of fencing agents configured for the host.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/hosts/123/fenceagents
-        ----
+        ```
         And here is sample response:
-        [source,xml]
-        ----
+        
+        ```xml
         <agents>
           <agent id="0">
             <type>apc</type>
@@ -10814,22 +11333,27 @@ class FenceAgentsService(Service):
             <options>name1=value1, name2=value2</options>
           </agent>
         </agents>
-        ----
+        ```
         The order of the returned list of fencing agents isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of agents to return. If not specified all the agents are returned.
+        `max` \n
+        Sets the maximum number of agents to return. If not specified all the agents are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10892,14 +11416,18 @@ class FileService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -10960,34 +11488,42 @@ class FilesService(Service):
         parameter to `true`.
         The default value of the `refresh` parameter is `true`, but it can be changed using the configuration value
         `ForceRefreshDomainFilesByDefault`:
-        [source]
-        ----
+        
+        ```
         # engine-config -s ForceRefreshDomainFilesByDefault=false
-        ----
+        ```
         IMPORTANT: Setting the value of the `refresh` parameter to `true` has an impact on the performance of the
         server. Use it only if necessary.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of files to return. If not specified, all the files are returned.
+        `max` \n
+        Sets the maximum number of files to return. If not specified, all the files are returned.
 
-        `search`:: A query string used to restrict the returned files.
+        `search` \n
+        A query string used to restrict the returned files.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should take case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should take case into
         account. The default value is `true`.
 
-        `refresh`:: Indicates whether the list of files should be refreshed from the storage domain, rather than showing cached
+        `refresh` \n
+        Indicates whether the list of files should be refreshed from the storage domain, rather than showing cached
         results that are updated at certain intervals.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11059,16 +11595,21 @@ class FilterService(Service):
         """
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11098,13 +11639,17 @@ class FilterService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11187,18 +11732,24 @@ class FiltersService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of filters to return. If not specified all the filters are returned.
+        `max` \n
+        Sets the maximum number of filters to return. If not specified all the filters are returned.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11288,13 +11839,13 @@ class GlusterBricksService(Service):
         bricks. The bricks that were previously marked for removal will now be used as normal bricks.
         For example, to retain the bricks that on glustervolume `123` from which data was migrated, send a request like
         this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/567/glustervolumes/123/glusterbricks/activate
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <bricks>
             <brick>
@@ -11302,20 +11853,25 @@ class GlusterBricksService(Service):
             </brick>
           </bricks>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `bricks`:: The list of bricks that need to be re-activated.
+        `bricks` \n
+        The list of bricks that need to be re-activated.
 
-        `async_`:: Indicates if the activation should be performed asynchronously.
+        `async_` \n
+        Indicates if the activation should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11352,31 +11908,35 @@ class GlusterBricksService(Service):
         needs to be passed. In case the replica count is being increased, then the number of bricks needs to be
         equivalent to the number of replica sets.
         For example, to add bricks to gluster volume `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/567/glustervolumes/123/glusterbricks
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <bricks>
           <brick>
             <server_id>111</server_id>
             <brick_dir>/export/data/brick3</brick_dir>
           </brick>
         </bricks>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `bricks`:: The list of bricks to be added to the volume
+        `bricks` \n
+        The list of bricks to be added to the volume
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11409,13 +11969,13 @@ class GlusterBricksService(Service):
         """
         Lists the bricks of a gluster volume.
         For example, to list bricks of gluster volume `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusters/567/glustervolumes/123/glusterbricks
-        ----
+        ```
         Provides an output as below:
-        [source,xml]
-        ----
+        
+        ```xml
         <bricks>
           <brick id="234">
             <name>host1:/rhgs/data/brick1</name>
@@ -11430,22 +11990,27 @@ class GlusterBricksService(Service):
             <status>up</status>
           </brick>
         </bricks>
-        ----
+        ```
         The order of the returned list is based on the brick order provided at gluster volume creation.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of bricks to return. If not specified all the bricks are returned.
+        `max` \n
+        Sets the maximum number of bricks to return. If not specified all the bricks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11477,16 +12042,16 @@ class GlusterBricksService(Service):
         Start migration of data prior to removing bricks.
         Removing bricks is a two-step process, where the data on bricks to be removed, is first migrated to remaining
         bricks. Once migration is completed the removal of bricks is confirmed via the API
-        xref:services-gluster_bricks-methods-remove[remove]. If at any point, the action needs to be cancelled
-        xref:services-gluster_bricks-methods-stop_migrate[stopmigrate] has to be called.
-        For instance, to delete a brick from a gluster volume with id `123`, send a request:
-        [source]
-        ----
+        `GlusterBricksService.remove`. If at any point, the action needs to be cancelled
+        `GlusterBricksService.stop_migrate` has to be called.For instance, 
+        to delete a brick from a gluster volume with id `123`, send a request:
+        
+        ```
         POST /ovirt-engine/api/clusters/567/glustervolumes/123/glusterbricks/migrate
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <bricks>
             <brick>
@@ -11494,22 +12059,26 @@ class GlusterBricksService(Service):
             </brick>
           </bricks>
         </action>
-        ----
+        ```
         The migration process can be tracked from the job id returned from the API using
-        xref:services-job-methods-get[job] and steps in job using xref:services-step-methods-get[step]
-
+        `JobService.get` and steps in job using `StepService.get`.
 
         This method supports the following parameters:
 
-        `bricks`:: List of bricks for which data migration needs to be started.
+        `bricks` \n
+        List of bricks for which data migration needs to be started.
 
-        `async_`:: Indicates if the migration should be performed asynchronously.
+        `async_` \n
+        Indicates if the migration should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11543,37 +12112,43 @@ class GlusterBricksService(Service):
         """
         Removes bricks from gluster volume.
         The recommended way to remove bricks without data loss is to first migrate the data using
-        xref:services-gluster_bricks-methods-stop_migrate[stopmigrate] and then removing them. If migrate was not called on
+        `GlusterBricksService.stop_migrate` and then removing them. If migrate was not called on
         bricks prior to remove, the bricks are removed without data migration which may lead to data loss.
         For example, to delete the bricks from gluster volume `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/clusters/567/glustervolumes/123/glusterbricks
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <bricks>
           <brick>
             <name>host:brick_directory</name>
           </brick>
         </bricks>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `bricks`:: The list of bricks to be removed
+        `bricks` \n
+        The list of bricks to be removed
 
-        `replica_count`:: Replica count of volume post add operation.
+        `replica_count` \n
+        Replica count of volume post add operation.
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11615,33 +12190,38 @@ class GlusterBricksService(Service):
         continue using the bricks. The bricks that were marked for removal will function as normal bricks post this
         operation.
         For example, to stop migration of data from the bricks of gluster volume `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/567/glustervolumes/123/glusterbricks/stopmigrate
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <bricks>
           <brick>
             <name>host:brick_directory</name>
           </brick>
         </bricks>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `bricks`:: List of bricks for which data migration needs to be stopped. This list should match the arguments passed to
-        xref:services-gluster_bricks-methods-migrate[migrate].
+        `bricks` \n
+        List of bricks for which data migration needs to be stopped. This list should match the arguments passed to
+        `GlusterBricksService.migrate`.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11709,13 +12289,17 @@ class GlusterHookService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11749,13 +12333,17 @@ class GlusterHookService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11785,14 +12373,18 @@ class GlusterHookService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11821,13 +12413,17 @@ class GlusterHookService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11869,13 +12465,17 @@ class GlusterHookService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -11934,16 +12534,21 @@ class GlusterHooksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of hooks to return. If not specified all the hooks are returned.
+        `max` \n
+        Sets the maximum number of hooks to return. If not specified all the hooks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12008,13 +12613,13 @@ class GlusterVolumesService(Service):
         The volume is created based on properties of the `volume` parameter. The properties `name`, `volume_type` and
         `bricks` are required.
         For example, to add a volume with name `myvolume` to the cluster `123`, send the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/123/glustervolumes
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <gluster_volume>
           <name>myvolume</name>
           <volume_type>replicate</volume_type>
@@ -12034,19 +12639,23 @@ class GlusterVolumesService(Service):
             </brick>
           <bricks>
         </gluster_volume>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `volume`:: The gluster volume definition from which to create the volume is passed as input and the newly created
+        `volume` \n
+        The gluster volume definition from which to create the volume is passed as input and the newly created
         volume is returned.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12074,31 +12683,38 @@ class GlusterVolumesService(Service):
         Lists all gluster volumes in the cluster.
         For example, to list all Gluster Volumes in cluster `456`, send a request like
         this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusters/456/glustervolumes
-        ----
+        ```
         The order of the returned list of volumes isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of volumes to return. If not specified all the volumes are returned.
+        `max` \n
+        Sets the maximum number of volumes to return. If not specified all the volumes are returned.
 
-        `search`:: A query string used to restrict the returned volumes.
+        `search` \n
+        A query string used to restrict the returned volumes.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12152,8 +12768,7 @@ class GlusterVolumesService(Service):
 class GroupService(Service):
     """
     Manages a group of users. Use this service to either get groups details or remove groups. In order
-    to add new groups please use xref:services-groups[service] that manages the collection of groups.
-
+    to add new groups please use `GroupsService` that manages the collection of groups.
     """
 
     def __init__(self, connection, path):
@@ -12173,12 +12788,12 @@ class GroupService(Service):
         """
         Gets the system group information.
         Usage:
-        ....
+        ```
         GET /ovirt-engine/api/groups/123
-        ....
+        ```
         Will return the group information:
-        [source,xml]
-        ----
+        
+        ```xml
         <group href="/ovirt-engine/api/groups/123" id="123">
           <name>mygroup</name>
           <link href="/ovirt-engine/api/groups/123/roles" rel="roles"/>
@@ -12190,19 +12805,23 @@ class GroupService(Service):
             <name>myextension-authz</name>
           </domain>
         </group>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12228,20 +12847,24 @@ class GroupService(Service):
         """
         Removes the system group.
         Usage:
-        ....
+        ```
         DELETE /ovirt-engine/api/groups/123
-        ....
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12328,31 +12951,35 @@ class GroupsService(Service):
         Add group from a directory service. Please note that domain name is name of the authorization provider.
         For example, to add the `Developers` group from the `internal-authz` authorization provider send a request
         like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/groups
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <group>
           <name>Developers</name>
           <domain>
             <name>internal-authz</name>
           </domain>
         </group>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `group`:: The group to be added.
+        `group` \n
+        The group to be added.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12379,12 +13006,12 @@ class GroupsService(Service):
         """
         List all the groups in the system.
         Usage:
-        ....
+        ```
         GET /ovirt-engine/api/groups
-        ....
+        ```
         Will return the list of groups:
-        [source,xml]
-        ----
+        
+        ```xml
         <groups>
           <group href="/ovirt-engine/api/groups/123" id="123">
             <name>mygroup</name>
@@ -12399,28 +13026,35 @@ class GroupsService(Service):
           </group>
           ...
         </groups>
-        ----
+        ```
         The order of the returned list of groups isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of groups to return. If not specified all the groups are returned.
+        `max` \n
+        Sets the maximum number of groups to return. If not specified all the groups are returned.
 
-        `search`:: A query string used to restrict the returned groups.
+        `search` \n
+        A query string used to restrict the returned groups.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12494,14 +13128,18 @@ class HostCpuUnitsService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12548,12 +13186,12 @@ class HostDeviceService(Service):
         """
         Retrieve information about a particular host's device.
         An example of getting a host device:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/hosts/123/devices/456
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <host_device href="/ovirt-engine/api/hosts/123/devices/456" id="456">
           <name>usb_1_9_1_1_0</name>
           <capability>usb</capability>
@@ -12562,19 +13200,23 @@ class HostDeviceService(Service):
             <name>usb_1_9_1</name>
           </parent_device>
         </host_device>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12627,16 +13269,21 @@ class HostDevicesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of devices to return. If not specified all the devices are returned.
+        `max` \n
+        Sets the maximum number of devices to return. If not specified all the devices are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12698,14 +13345,18 @@ class HostHookService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12756,16 +13407,21 @@ class HostHooksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of hooks to return. If not specified, all the hooks are returned.
+        `max` \n
+        Sets the maximum number of hooks to return. If not specified, all the hooks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12834,27 +13490,33 @@ class HostNicsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of NICs to return. If not specified all the NICs are returned.
+        `max` \n
+        Sets the maximum number of NICs to return. If not specified all the NICs are returned.
 
-        `all_content`:: Indicates if all of the attributes of the host network interface should be included in the response.
+        `all_content` \n
+        Indicates if all of the attributes of the host network interface should be included in the response.
         By default the following attributes are excluded:
         - `virtual_functions_configuration`
         For example, to retrieve the complete representation of network interface '456' of host '123':
-        ....
+        ```
         GET /ovirt-engine/api/hosts/123/nics?all_content=true
-        ....
+        ```
         NOTE: These attributes are not included by default because retrieving them impacts performance. They are
         seldom used and require additional queries to the database. Use this parameter with caution and only when
         specifically required.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12926,16 +13588,21 @@ class HostNumaNodesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of nodes to return. If not specified all the nodes are returned.
+        `max` \n
+        Sets the maximum number of nodes to return. If not specified all the nodes are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -12998,33 +13665,34 @@ class HostStorageService(Service):
     ):
         """
         Get list of storages.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/hosts/123/storage
-        ----
+        ```
         The XML response you get will be like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <host_storages>
           <host_storage id="123">
             ...
           </host_storage>
           ...
         </host_storages>
-        ----
+        ```
         The order of the returned list of storages isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `report_status`:: Indicates if the status of the LUNs in the storage should be checked.
+        `report_status` \n
+        Indicates if the status of the LUNs in the storage should be checked.
         Checking the status of the LUN is an heavy weight operation and
         this data is not always needed by the user.
         This parameter will give the option to not perform the status check of the LUNs.
         The default is `true` for backward compatibility.
         Here an example with the LUN status :
-        [source,xml]
-        ----
+        
+        ```xml
         <host_storage id="123">
           <logical_units>
             <logical_unit id="123">
@@ -13041,10 +13709,10 @@ class HostStorageService(Service):
           <type>iscsi</type>
           <host id="123"/>
         </host_storage>
-        ----
+        ```
         Here an example without the LUN status :
-        [source,xml]
-        ----
+        
+        ```xml
         <host_storage id="123">
           <logical_units>
             <logical_unit id="123">
@@ -13060,16 +13728,20 @@ class HostStorageService(Service):
           <type>iscsi</type>
           <host id="123"/>
         </host_storage>
-        ----
+        ```
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13140,41 +13812,41 @@ class HostsService(Service):
         The host is created based on the attributes of the `host` parameter. The `name`, `address`, and `root_password`
         properties are required.
         For example, to add a host, send the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <host>
           <name>myhost</name>
           <address>myhost.example.com</address>
           <root_password>myrootpassword</root_password>
         </host>
-        ----
+        ```
         NOTE: The `root_password` element is only included in the client-provided initial representation and is not
         exposed in the representations returned from subsequent requests.
         IMPORTANT: Since version 4.1.2 of the engine, when a host is newly added, the host's firewall
         definitions are overridden by default.
         To add a hosted engine host, use the optional `deploy_hosted_engine` parameter:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts?deploy_hosted_engine=true
-        ----
+        ```
         If the cluster has a default external network provider that is supported for automatic deployment,
         the external network provider is deployed when adding the host.
         Only external network providers for OVN are supported for the automatic deployment.
         To deploy an external network provider other than the one defined in the clusters, overwrite the external
         network provider when adding hosts, by sending the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts
-        ----
+        ```
         With a request body that contains a reference to the desired provider in the
         `external_network_provider_configuration`:
-        [source,xml]
-        ----
+        
+        ```xml
         <host>
           <name>myhost</name>
           <address>myhost.example.com</address>
@@ -13185,19 +13857,23 @@ class HostsService(Service):
             </external_network_provider_configuration>
           </external_network_provider_configurations>
         </host>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `host`:: The host definition with which the new host is created is passed as a parameter, and the newly created host
+        `host` \n
+        The host definition with which the new host is created is passed as a parameter, and the newly created host
         is returned.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13244,12 +13920,12 @@ class HostsService(Service):
         """
         Get a list of all available hosts.
         For example, to list the hosts send the following request:
-        ....
+        ```
         GET /ovirt-engine/api/hosts
-        ....
+        ```
         The response body will be similar to this:
-        [source,xml]
-        ----
+        
+        ```xml
         <hosts>
           <host href="/ovirt-engine/api/hosts/123" id="123">
             ...
@@ -13259,61 +13935,72 @@ class HostsService(Service):
           </host>
           ...
         </host>
-        ----
+        ```
         The order of the returned list of hosts is guaranteed only if the `sortby` clause is included in
         the `search` parameter.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of hosts to return. If not specified all the hosts are returned.
+        `max` \n
+        Sets the maximum number of hosts to return. If not specified all the hosts are returned.
 
-        `search`:: A query string used to restrict the returned hosts.
+        `search` \n
+        A query string used to restrict the returned hosts.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `all_content`:: Indicates if all of the attributes of the hosts should be included in the response.
+        `all_content` \n
+        Indicates if all of the attributes of the hosts should be included in the response.
         By default the following host attributes are excluded:
         - `hosted_engine`
         For example, to retrieve the complete representation of the hosts:
-        ....
+        ```
         GET /ovirt-engine/api/hosts?all_content=true
-        ....
+        ```
         NOTE: These attributes are not included by default because retrieving them impacts performance. They are
         seldom used and require additional queries to the database. Use this parameter with caution and only when
         specifically required.
 
-        `migration_target_of`:: Accepts a comma-separated list of virtual machine IDs and returns the hosts
+        `migration_target_of` \n
+        Accepts a comma-separated list of virtual machine IDs and returns the hosts
         that these virtual machines can be migrated to.
         For example, to retrieve the list of hosts to which the virtual machine with ID 123 and
         the virtual machine with ID 456 can be migrated to, send the following request:
-        ....
+        ```
         GET /ovirt-engine/api/hosts?migration_target_of=123,456
-        ....
+        ```
 
-        `check_vms_in_affinity_closure`:: This parameter can be used with `migration_target_of`
+        `check_vms_in_affinity_closure` \n
+        This parameter can be used with `migration_target_of`
         to get valid migration targets for the listed virtual machines
         and all other virtual machines that are in positive enforcing
         affinity with the listed virtual machines.
         This is useful in case the virtual machines will be migrated
         together with others in positive affinity groups.
         The default value is `false`.
-        ....
+        ```
         GET /ovirt-engine/api/hosts?migration_target_of=123,456&check_vms_in_affinity_closure=true
-        ....
+        ```
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13372,14 +14059,18 @@ class HostsService(Service):
 
         This method supports the following parameters:
 
-        `host`:: The host definition with which the new host is created is passed as a parameter, and the newly created host
+        `host` \n
+        The host definition with which the new host is created is passed as a parameter, and the newly created host
         is returned.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13426,14 +14117,18 @@ class HostsService(Service):
 
         This method supports the following parameters:
 
-        `host`:: The host definition with which the new host is created is passed as a parameter, and the newly created host
+        `host` \n
+        The host definition with which the new host is created is passed as a parameter, and the newly created host
         is returned.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13506,30 +14201,34 @@ class IconService(Service):
     ):
         """
         Get an icon.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/icons/123
-        ----
+        ```
         You will get a XML response like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <icon id="123">
           <data>Some binary data here</data>
           <media_type>image/png</media_type>
         </icon>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13577,13 +14276,13 @@ class IconsService(Service):
     ):
         """
         Get a list of icons.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/icons
-        ----
+        ```
         You will get a XML response which is similar to this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <icons>
           <icon id="123">
             <data>...</data>
@@ -13591,22 +14290,27 @@ class IconsService(Service):
           </icon>
           ...
         </icons>
-        ----
+        ```
         The order of the returned list of icons isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of icons to return. If not specified all the icons are returned.
+        `max` \n
+        Sets the maximum number of icons to return. If not specified all the icons are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13668,14 +14372,18 @@ class ImageService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13719,25 +14427,34 @@ class ImageService(Service):
 
         This method supports the following parameters:
 
-        `cluster`:: The cluster to which the image should be imported if the `import_as_template` parameter
+        `cluster` \n
+        The cluster to which the image should be imported if the `import_as_template` parameter
         is set to `true`.
 
-        `disk`:: The disk to import.
+        `disk` \n
+        The disk to import.
 
-        `import_as_template`:: Specifies if a template should be created from the imported disk.
+        `import_as_template` \n
+        Specifies if a template should be created from the imported disk.
 
-        `template`:: The name of the template being created if the
+        `template` \n
+        The name of the template being created if the
         `import_as_template` parameter is set to `true`.
 
-        `storage_domain`:: The storage domain to which the disk should be imported.
+        `storage_domain` \n
+        The storage domain to which the disk should be imported.
 
-        `async_`:: Indicates if the import should be performed asynchronously.
+        `async_` \n
+        Indicates if the import should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13781,14 +14498,12 @@ class ImageService(Service):
 class ImageTransferService(Service):
     """
     This service provides a mechanism to control an image transfer. The client will have
-    to create a transfer by using xref:services-image_transfers-methods-add[add]
-    of the xref:services-image_transfers[image transfers] service, stating the image to transfer
-    data to/from.
-    After doing that, the transfer is managed by this service.
+    to create a transfer by using `ImageTransfersService.add` of the `ImageTransfersService`
+    service, stating the image to transfer data to/from. After doing that, the transfer is managed by this service.
     *Using oVirt's Python's SDK:*
     Uploading a `disk` with id `123` (on a random host in the data center):
-    [source,python]
-    ----
+
+    ```python
     transfers_service = system_service.image_transfers_service()
     transfer = transfers_service.add(
        types.ImageTransfer(
@@ -13797,10 +14512,9 @@ class ImageTransferService(Service):
           )
        )
     )
-    ----
+    ```
     Uploading a `disk` with id `123` on `host` id `456`:
-    [source,python]
-    ----
+    ```python
     transfers_service = system_service.image_transfers_service()
     transfer = transfers_service.add(
        types.ImageTransfer(
@@ -13812,13 +14526,12 @@ class ImageTransferService(Service):
          )
        )
     )
-    ----
+    ```
     If the user wishes to download a disk rather than upload, he/she should specify
-    `download` as the xref:types-image_transfer_direction[direction] attribute of the transfer.
+    `download` as the `ImageTransfer.direction` attribute of the transfer.
     This will grant a read permission from the image, instead of a write permission.
     E.g:
-    [source,python]
-    ----
+    ```python
     transfers_service = system_service.image_transfers_service()
     transfer = transfers_service.add(
        types.ImageTransfer(
@@ -13828,26 +14541,23 @@ class ImageTransferService(Service):
           direction=types.ImageTransferDirection.DOWNLOAD
        )
     )
-    ----
+    ```
     Transfers have phases, which govern the flow of the upload/download.
     A client implementing such a flow should poll/check the transfer's phase and
-    act accordingly. All the possible phases can be found in
-    xref:types-image_transfer_phase[ImageTransferPhase].
-    After adding a new transfer, its phase will be xref:types-image_transfer_phase[initializing].
+    act accordingly. All the possible phases can be found in `ovirtsdk4.types.ImageTransferPhase`.
+    After adding a new transfer, its phase will be `ovirtsdk4.types.ImageTransferPhase.INITIALIZING`.
     The client will have to poll on the transfer's phase until it changes.
-    When the phase becomes xref:types-image_transfer_phase[transferring],
+    When the phase becomes `ovirtsdk4.types.ImageTransferPhase.TRANSFERRING`,
     the session is ready to start the transfer.
     For example:
-    [source,python]
-    ----
+    ```python
     transfer_service = transfers_service.image_transfer_service(transfer.id)
     while transfer.phase == types.ImageTransferPhase.INITIALIZING:
        time.sleep(3)
        transfer = transfer_service.get()
-    ----
-    At that stage, if the phase of the transfer is xref:types-image_transfer_phase[paused_system], the session was
+    ```
+    At that stage, if the phase of the transfer is `ovirtsdk4.types.ImageTransferPhase.PAUSED_SYSTEM`, the session was
     not successfully established. This can happen if ovirt-imageio is not running in the selected host.
-
     """
 
     def __init__(self, connection, path):
@@ -13862,8 +14572,6 @@ class ImageTransferService(Service):
     ):
         """
         Cancel the image transfer session. This terminates the transfer operation and removes the partial image.
-
-
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13940,14 +14648,18 @@ class ImageTransferService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -13995,15 +14707,15 @@ class ImageTransferService(Service):
         """
         Resume the image transfer session. The client will need to poll the transfer's phase until
         it is different than `resuming`. For example:
-        [source,python]
-        ----
+
+        ```python
         transfer_service = transfers_service.image_transfer_service(transfer.id)
         transfer_service.resume()
         transfer = transfer_service.get()
         while transfer.phase == types.ImageTransferPhase.RESUMING:
            time.sleep(1)
            transfer = transfer_service.get()
-        ----
+        ```
 
 
         """
@@ -14033,9 +14745,7 @@ class ImageTransferService(Service):
 class ImageTransfersService(Service):
     """
     This service manages image transfers, for performing Image I/O API in {product-name}.
-    Please refer to xref:services-image_transfer[image transfer] for further
-    documentation.
-
+    Please refer to `ImageTransferService` for further documentation.
     """
 
     def __init__(self, connection, path):
@@ -14058,44 +14768,48 @@ class ImageTransfersService(Service):
         *Creating a new image transfer for downloading or uploading a `disk`:*
         To create an image transfer to download or upload a disk with id `123`,
         send the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/imagetransfers
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <image_transfer>
           <disk id="123"/>
           <direction>upload|download</direction>
         </image_transfer>
-        ----
+        ```
         *Creating a new image transfer for downloading or uploading a `disk_snapshot`:*
         To create an image transfer to download or upload a `disk_snapshot` with id `456`,
         send the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/imagetransfers
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <image_transfer>
           <snapshot id="456"/>
           <direction>download|upload</direction>
         </image_transfer>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `image_transfer`:: The image transfer to add.
+        `image_transfer` \n
+        The image transfer to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14119,13 +14833,17 @@ class ImageTransfersService(Service):
         """
         This method supports the following parameters:
 
-        `image_transfer`:: The image transfer to add.
+        `image_transfer` \n
+        The image transfer to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14149,13 +14867,17 @@ class ImageTransfersService(Service):
         """
         This method supports the following parameters:
 
-        `image_transfer`:: The image transfer to add.
+        `image_transfer` \n
+        The image transfer to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14179,13 +14901,17 @@ class ImageTransfersService(Service):
         """
         This method supports the following parameters:
 
-        `image_transfer`:: The image transfer to add.
+        `image_transfer` \n
+        The image transfer to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14214,14 +14940,18 @@ class ImageTransfersService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14288,16 +15018,21 @@ class ImagesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of images to return. If not specified all the images are returned.
+        `max` \n
+        Sets the maximum number of images to return. If not specified all the images are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14359,22 +15094,26 @@ class InstanceTypeService(Service):
     ):
         """
         Get a specific instance type and it's attributes.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/instancetypes/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14401,21 +15140,25 @@ class InstanceTypeService(Service):
         Removes a specific instance type from the system.
         If a virtual machine was created using an instance type X after removal of the instance type
         the virtual machine's instance type will be set to `custom`.
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/instancetypes/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14450,14 +15193,14 @@ class InstanceTypeService(Service):
         If a virtual machine was created using an instance type X and some configuration in instance
         type X was updated, the virtual machine's configuration will be updated automatically by the
         engine.
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/instancetypes/123
-        ----
+        ```
         For example, to update the memory of instance type `123` to 1 GiB and set the cpu topology
         to 2 sockets and 1 core, send a request like this:
-        [source, xml]
-        ----
+
+        ```xml
         <instance_type>
           <memory>1073741824</memory>
           <cpu>
@@ -14468,7 +15211,7 @@ class InstanceTypeService(Service):
             </topology>
           </cpu>
         </instance_type>
-        ----
+        ```
 
 
         """
@@ -14558,14 +15301,18 @@ class InstanceTypeGraphicsConsoleService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14594,13 +15341,17 @@ class InstanceTypeGraphicsConsoleService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14680,16 +15431,21 @@ class InstanceTypeGraphicsConsolesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of consoles to return. If not specified all the consoles are returned.
+        `max` \n
+        Sets the maximum number of consoles to return. If not specified all the consoles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14754,14 +15510,18 @@ class InstanceTypeNicService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14790,13 +15550,17 @@ class InstanceTypeNicService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14910,18 +15674,24 @@ class InstanceTypeNicsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of NICs to return. If not specified all the NICs are returned.
+        `max` \n
+        Sets the maximum number of NICs to return. If not specified all the NICs are returned.
 
-        `search`:: A query string used to restrict the returned templates.
+        `search` \n
+        A query string used to restrict the returned templates.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -14987,14 +15757,18 @@ class InstanceTypeWatchdogService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15023,13 +15797,17 @@ class InstanceTypeWatchdogService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15143,19 +15921,25 @@ class InstanceTypeWatchdogsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of watchdogs to return. If not specified all the watchdogs are
+        `max` \n
+        Sets the maximum number of watchdogs to return. If not specified all the watchdogs are
         returned.
 
-        `search`:: A query string used to restrict the returned templates.
+        `search` \n
+        A query string used to restrict the returned templates.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15220,20 +16004,20 @@ class InstanceTypesService(Service):
         Creates a new instance type.
         This requires only a name attribute and can include all hardware configurations of the
         virtual machine.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/instancetypes
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <instance_type>
           <name>myinstancetype</name>
         </template>
-        ----
+        ```
         Creating an instance type with all hardware configurations with a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <instance_type>
           <name>myinstancetype</name>
           <console>
@@ -15295,7 +16079,7 @@ class InstanceTypesService(Service):
             <enabled>true</enabled>
           </virtio_scsi>
         </instance_type>
-        ----
+        ```
 
 
         """
@@ -15328,23 +16112,30 @@ class InstanceTypesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of instance types to return. If not specified all the instance
+        `max` \n
+        Sets the maximum number of instance types to return. If not specified all the instance
         types are returned.
 
-        `search`:: A query string used to restrict the returned templates.
+        `search` \n
+        A query string used to restrict the returned templates.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed
         taking case into account. The default value is `true`, which means that case is taken
         into account. If you want to search ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15413,14 +16204,18 @@ class IscsiBondService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15446,21 +16241,25 @@ class IscsiBondService(Service):
         """
         Removes of an existing iSCSI bond.
         For example, to remove the iSCSI bond `456` send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/datacenters/123/iscsibonds/456
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15493,29 +16292,33 @@ class IscsiBondService(Service):
         Updates an iSCSI bond.
         Updating of an iSCSI bond can be done on the `name` and the `description` attributes only. For example, to
         update the iSCSI bond `456` of data center `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/datacenters/123/iscsibonds/1234
-        ----
+        ```
         The request body should look like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <iscsi_bond>
            <name>mybond</name>
            <description>My iSCSI bond</description>
         </iscsi_bond>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `bond`:: The iSCSI bond to update.
+        `bond` \n
+        The iSCSI bond to update.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15586,13 +16389,13 @@ class IscsiBondsService(Service):
         Create a new iSCSI bond on a data center.
         For example, to create a new iSCSI bond on data center `123` using storage connections `456` and `789`, send a
         request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/iscsibonds
-        ----
+        ```
         The request body should look like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <iscsi_bond>
           <name>mybond</name>
           <storage_connections>
@@ -15603,7 +16406,7 @@ class IscsiBondsService(Service):
             <network id="abc"/>
           </networks>
         </iscsi_bond>
-        ----
+        ```
 
 
         """
@@ -15634,16 +16437,21 @@ class IscsiBondsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of bonds to return. If not specified all the bonds are returned.
+        `max` \n
+        Sets the maximum number of bonds to return. If not specified all the bonds are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15706,26 +16514,30 @@ class JobService(Service):
         """
         Set an external job execution to be cleared by the system.
         For example, to set a job with identifier `123` send the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/jobs/clear
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15757,34 +16569,40 @@ class JobService(Service):
         """
         Marks an external job execution as ended.
         For example, to terminate a job with identifier `123` send the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/jobs/end
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <force>true</force>
           <status>finished</status>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `force`:: Indicates if the job should be forcibly terminated.
+        `force` \n
+        Indicates if the job should be forcibly terminated.
 
-        `succeeded`:: Indicates if the job should be marked as successfully finished or as failed.
+        `succeeded` \n
+        Indicates if the job should be marked as successfully finished or as failed.
         This parameter is optional, and the default value is `true`.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15817,13 +16635,13 @@ class JobService(Service):
     ):
         """
         Retrieves a job.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/jobs/123
-        ----
+        ```
         You will receive response in XML like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <job href="/ovirt-engine/api/jobs/123" id="123">
           <actions>
             <link href="/ovirt-engine/api/jobs/123/clear" rel="clear"/>
@@ -15839,19 +16657,23 @@ class JobService(Service):
           <status>failed</status>
           <owner href="/ovirt-engine/api/users/456" id="456"/>
         </job>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15911,21 +16733,21 @@ class JobsService(Service):
         """
         Add an external job.
         For example, to add a job with the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/jobs
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <job>
           <description>Doing some work</description>
           <auto_cleared>true</auto_cleared>
         </job>
-        ----
+        ```
         The response should look like:
-        [source,xml]
-        ----
+        
+        ```xml
         <job href="/ovirt-engine/api/jobs/123" id="123">
           <actions>
             <link href="/ovirt-engine/api/jobs/123/clear" rel="clear"/>
@@ -15940,18 +16762,22 @@ class JobsService(Service):
           <status>started</status>
           <owner href="/ovirt-engine/api/users/456" id="456"/>
         </job>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `job`:: Job that will be added.
+        `job` \n
+        Job that will be added.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -15977,13 +16803,13 @@ class JobsService(Service):
     ):
         """
         Retrieves the representation of the jobs.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/jobs
-        ----
+        ```
         You will receive response in XML like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <jobs>
           <job href="/ovirt-engine/api/jobs/123" id="123">
             <actions>
@@ -16002,28 +16828,35 @@ class JobsService(Service):
           </job>
           ...
         </jobs>
-        ----
+        ```
         The order of the returned list of jobs isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `search`:: A query string used to restrict the returned jobs.
+        `search` \n
+        A query string used to restrict the returned jobs.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `max`:: Sets the maximum number of jobs to return. If not specified all the jobs are returned.
+        `max` \n
+        Sets the maximum number of jobs to return. If not specified all the jobs are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16096,13 +16929,13 @@ class KatelloErrataService(Service):
     ):
         """
         Retrieves the representation of the Katello errata.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/katelloerrata
-        ----
+        ```
         You will receive response in XML like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <katello_errata>
           <katello_erratum href="/ovirt-engine/api/katelloerrata/123" id="123">
             <name>RHBA-2013:XYZ</name>
@@ -16121,22 +16954,27 @@ class KatelloErrataService(Service):
           </katello_erratum>
           ...
         </katello_errata>
-        ----
+        ```
         The order of the returned list of erratum isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of errata to return. If not specified all the errata are returned.
+        `max` \n
+        Sets the maximum number of errata to return. If not specified all the errata are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16200,13 +17038,13 @@ class KatelloErratumService(Service):
     ):
         """
         Retrieves a Katello erratum.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/katelloerrata/123
-        ----
+        ```
         You will receive response in XML like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <katello_erratum href="/ovirt-engine/api/katelloerrata/123" id="123">
           <name>RHBA-2013:XYZ</name>
           <description>The description of the erratum</description>
@@ -16222,19 +17060,23 @@ class KatelloErratumService(Service):
             ...
           </packages>
         </katello_erratum>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16284,14 +17126,18 @@ class LinkLayerDiscoveryProtocolService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16337,14 +17183,18 @@ class MacPoolService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16370,21 +17220,25 @@ class MacPoolService(Service):
         """
         Removes a MAC address pool.
         For example, to remove the MAC address pool having id `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/macpools/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16417,13 +17271,13 @@ class MacPoolService(Service):
         Updates a MAC address pool.
         The `name`, `description`, `allow_duplicates`, and `ranges` attributes can be updated.
         For example, to update the MAC address pool of id `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/macpools/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <mac_pool>
           <name>UpdatedMACPool</name>
           <description>An updated MAC address pool</description>
@@ -16439,7 +17293,7 @@ class MacPoolService(Service):
             </range>
           </ranges>
         </mac_pool>
-        ----
+        ```
 
 
         """
@@ -16505,13 +17359,13 @@ class MacPoolsService(Service):
         Creates a new MAC address pool.
         Creation of a MAC address pool requires values for the `name` and `ranges` attributes.
         For example, to create MAC address pool send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/macpools
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <mac_pool>
           <name>MACPool</name>
           <description>A MAC address pool</description>
@@ -16524,7 +17378,7 @@ class MacPoolsService(Service):
             </range>
           </ranges>
         </mac_pool>
-        ----
+        ```
 
 
         """
@@ -16555,16 +17409,21 @@ class MacPoolsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of pools to return. If not specified all the pools are returned.
+        `max` \n
+        Sets the maximum number of pools to return. If not specified all the pools are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16653,13 +17512,17 @@ class MoveableService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the move should be performed asynchronously.
+        `async_` \n
+        Indicates if the move should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16713,13 +17576,13 @@ class NetworkService(Service):
         """
         Gets a logical network.
         For example:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/networks/123
-        ----
+        ```
         Will respond:
-        [source,xml]
-        ----
+        
+        ```xml
         <network href="/ovirt-engine/api/networks/123" id="123">
           <name>ovirtmgmt</name>
           <description>Default Management Network</description>
@@ -16733,19 +17596,23 @@ class NetworkService(Service):
           </usages>
           <data_center href="/ovirt-engine/api/datacenters/456" id="456"/>
         </network>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16771,34 +17638,38 @@ class NetworkService(Service):
         """
         Removes a logical network, or the association of a logical network to a data center.
         For example, to remove the logical network `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/networks/123
-        ----
+        ```
         Each network is bound exactly to one data center. So if we disassociate network with data center it has the same
         result as if we would just remove that network. However it might be more specific to say we're removing network
         `456` of data center `123`.
         For example, to remove the association of network `456` to data center `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/datacenters/123/networks/456
-        ----
+        ```
         NOTE: To remove an external logical network, the network has to be removed directly from its provider by
-        link:https://developer.openstack.org/api-ref/network[OpenStack Networking API].
+        link:https://developer.openstack.org/api-ref/network.
         The entity representing the external network inside {product-name} is removed automatically,
-        if xref:types-open_stack_network_provider-attributes-auto_sync[`auto_sync`] is enabled for the provider,
+        if `ovirtsdk4.types.OpenStackNetworkProvider.auto_sync` is enabled for the provider,
         otherwise the entity has to be removed using this method.
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16831,31 +17702,31 @@ class NetworkService(Service):
         Updates a logical network.
         The `name`, `description`, `ip`, `vlan`, `stp` and `display` attributes can be updated.
         For example, to update the description of the logical network `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/networks/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <network>
           <description>My updated description</description>
         </network>
-        ----
+        ```
         The maximum transmission unit of a network is set using a PUT request to
         specify the integer value of the `mtu` attribute.
         For example, to set the maximum transmission unit send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/datacenters/123/networks/456
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <network>
           <mtu>1500</mtu>
         </network>
-        ----
+        ```
         NOTE: Updating external networks is not propagated to the provider.
 
 
@@ -16942,14 +17813,18 @@ class NetworkAttachmentService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -16975,13 +17850,17 @@ class NetworkAttachmentService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17096,16 +17975,21 @@ class NetworkAttachmentsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of attachments to return. If not specified all the attachments are returned.
+        `max` \n
+        Sets the maximum number of attachments to return. If not specified all the attachments are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17150,8 +18034,8 @@ class NetworkAttachmentsService(Service):
 class NetworkFilterService(Service):
     """
     Manages a network filter.
-    [source,xml]
-    ----
+    
+    ```xml
     <network_filter id="00000019-0019-0019-0019-00000000026b">
       <name>example-network-filter-b</name>
       <version>
@@ -17161,7 +18045,7 @@ class NetworkFilterService(Service):
         <revision>-1</revision>
       </version>
     </network_filter>
-    ----
+    ```
     Please note that version is referring to the minimal support version for the specific filter.
 
     """
@@ -17183,14 +18067,18 @@ class NetworkFilterService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17221,7 +18109,7 @@ class NetworkFiltersService(Service):
     """
     Represents a readonly network filters sub-collection.
     The network filter enables to filter packets send to/from the VM's nic according to defined rules.
-    For more information please refer to xref:services-network_filter[NetworkFilter] service documentation
+    For more information please refer to `NetworkFilterService` service documentation
     Network filters are supported in different versions, starting from version 3.0.
     A network filter is defined for each vnic profile.
     A vnic profile is defined for a specific network.
@@ -17233,13 +18121,13 @@ class NetworkFiltersService(Service):
     Please note, that if a network is assigned to cluster with a version supporting a network filter, the filter
     may not be available due to the data center version being smaller then the network filter's version.
     Example of listing all of the supported network filters for a specific cluster:
-    [source]
-    ----
+    
+    ```
     GET http://localhost:8080/ovirt-engine/api/clusters/{cluster:id}/networkfilters
-    ----
+    ```
     Output:
-    [source,xml]
-    ----
+    
+    ```xml
     <network_filters>
       <network_filter id="00000019-0019-0019-0019-00000000026c">
         <name>example-network-filter-a</name>
@@ -17269,7 +18157,7 @@ class NetworkFiltersService(Service):
         </version>
       </network_filter>
     </network_filters>
-    ----
+    ```
 
     """
 
@@ -17292,14 +18180,18 @@ class NetworkFiltersService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17355,14 +18247,18 @@ class NetworkLabelService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17388,21 +18284,25 @@ class NetworkLabelService(Service):
         """
         Removes a label from a logical network.
         For example, to remove the label `exemplary` from a logical network having id `123` send the following request:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/networks/123/networklabels/exemplary
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17457,15 +18357,15 @@ class NetworkLabelsService(Service):
         You can attach labels to a logical network to automate the association of that logical network with physical host
         network interfaces to which the same label has been attached.
         For example, to attach the label `mylabel` to a logical network having id `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/networks/123/networklabels
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <network_label id="mylabel"/>
-        ----
+        ```
 
 
         """
@@ -17496,16 +18396,21 @@ class NetworkLabelsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of labels to return. If not specified all the labels are returned.
+        `max` \n
+        Sets the maximum number of labels to return. If not specified all the labels are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17572,44 +18477,44 @@ class NetworksService(Service):
         Creates a new logical network, or associates an existing network with a data center.
         Creation of a new network requires the `name` and `data_center` elements.
         For example, to create a network named `mynetwork` for data center `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/networks
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <network>
           <name>mynetwork</name>
           <data_center id="123"/>
         </network>
-        ----
+        ```
         To associate the existing network `456` with the data center `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/networks
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <network>
           <name>ovirtmgmt</name>
         </network>
-        ----
+        ```
         To create a network named `exnetwork` on top of an external _OpenStack_ network provider `456` send a request
         like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/networks
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <network>
           <name>exnetwork</name>
           <external_provider id="456"/>
           <data_center id="123"/>
         </network>
-        ----
+        ```
 
 
         """
@@ -17638,13 +18543,13 @@ class NetworksService(Service):
         """
         List logical networks.
         For example:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/networks
-        ----
+        ```
         Will respond:
-        [source,xml]
-        ----
+        
+        ```xml
         <networks>
           <network href="/ovirt-engine/api/networks/123" id="123">
             <name>ovirtmgmt</name>
@@ -17661,29 +18566,36 @@ class NetworksService(Service):
           </network>
           ...
         </networks>
-        ----
+        ```
         The order of the returned list of networks is guaranteed only if the `sortby` clause is included in the
         `search` parameter.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of networks to return. If not specified all the networks are returned.
+        `max` \n
+        Sets the maximum number of networks to return. If not specified all the networks are returned.
 
-        `search`:: A query string used to restrict the returned networks.
+        `search` \n
+        A query string used to restrict the returned networks.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17757,14 +18669,18 @@ class NicNetworkFilterParameterService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17790,10 +18706,10 @@ class NicNetworkFilterParameterService(Service):
         Removes the filter parameter.
         For example, to remove the filter parameter with id `123` on NIC `456` of virtual machine `789`
         send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/vms/789/nics/456/networkfilterparameters/123
-        ----
+        ```
 
 
         """
@@ -17819,29 +18735,33 @@ class NicNetworkFilterParameterService(Service):
         Updates the network filter parameter.
         For example, to update the network filter parameter having with with id `123` on NIC `456` of
         virtual machine `789` send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/vms/789/nics/456/networkfilterparameters/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <network_filter_parameter>
           <name>updatedName</name>
           <value>updatedValue</value>
         </network_filter_parameter>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `parameter`:: The network filter parameter that is being updated.
+        `parameter` \n
+        The network filter parameter that is being updated.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17888,29 +18808,33 @@ class NicNetworkFilterParametersService(Service):
         Add a network filter parameter.
         For example, to add the parameter for the network filter on NIC `456` of
         virtual machine `789` send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/789/nics/456/networkfilterparameters
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <network_filter_parameter>
           <name>IP</name>
           <value>10.0.1.2</value>
         </network_filter_parameter>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `parameter`:: The network filter parameter that is being added.
+        `parameter` \n
+        The network filter parameter that is being added.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -17938,14 +18862,18 @@ class NicNetworkFilterParametersService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18003,14 +18931,18 @@ class OpenstackImageService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18042,13 +18974,13 @@ class OpenstackImageService(Service):
         Imports a virtual machine from a Glance image storage domain.
         For example, to import the image with identifier `456` from the
         storage domain with identifier `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/openstackimageproviders/123/images/456/import
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain>
             <name>images0</name>
@@ -18057,23 +18989,29 @@ class OpenstackImageService(Service):
             <name>images0</name>
           </cluster>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `import_as_template`:: Indicates whether the image should be imported as a template.
+        `import_as_template` \n
+        Indicates whether the image should be imported as a template.
 
-        `cluster`:: This parameter is mandatory in case of using `import_as_template` and indicates which cluster should be used
+        `cluster` \n
+        This parameter is mandatory in case of using `import_as_template` and indicates which cluster should be used
         for import glance image as template.
 
-        `async_`:: Indicates if the import should be performed asynchronously.
+        `async_` \n
+        Indicates if the import should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18134,14 +19072,18 @@ class OpenstackImageProviderService(ExternalProviderService):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18193,13 +19135,17 @@ class OpenstackImageProviderService(ExternalProviderService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18230,21 +19176,25 @@ class OpenstackImageProviderService(ExternalProviderService):
         """
         In order to test connectivity for external provider we need
         to run following request where 123 is an id of a provider.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/externalhostproviders/123/testconnectivity
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the test should be performed asynchronously.
+        `async_` \n
+        Indicates if the test should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18377,18 +19327,24 @@ class OpenstackImageProvidersService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of providers to return. If not specified all the providers are returned.
+        `max` \n
+        Sets the maximum number of providers to return. If not specified all the providers are returned.
 
-        `search`:: A query string used to restrict the returned OpenStack image providers.
+        `search` \n
+        A query string used to restrict the returned OpenStack image providers.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18457,16 +19413,21 @@ class OpenstackImagesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of images to return. If not specified all the images are returned.
+        `max` \n
+        Sets the maximum number of images to return. If not specified all the images are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18529,14 +19490,18 @@ class OpenstackNetworkService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18567,22 +19532,27 @@ class OpenstackNetworkService(Service):
 
         This method supports the following parameters:
 
-        `data_center`:: The data center into which the network is to be imported.
+        `data_center` \n
+        The data center into which the network is to be imported.
         Data center is mandatory, and can be specified
         using the `id` or `name` attributes. The rest of
         the attributes will be ignored.
-        NOTE: If xref:types-open_stack_network_provider-attributes-auto_sync[`auto_sync`] is
+        NOTE: If `ovirtsdk4.types.OpenStackNetworkProvider.auto_sync` is
         enabled for the provider, the network might be imported automatically. To
         prevent this, automatic import can be disabled by setting the `auto_sync` to false,
         and enabling it again after importing the network.
 
-        `async_`:: Indicates if the import should be performed asynchronously.
+        `async_` \n
+        Indicates if the import should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18646,22 +19616,26 @@ class OpenstackNetworkProviderService(ExternalProviderService):
         """
         Returns the representation of the object managed by this service.
         For example, to get the OpenStack network provider with identifier `1234`, send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/openstacknetworkproviders/1234
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18713,21 +19687,25 @@ class OpenstackNetworkProviderService(ExternalProviderService):
         """
         Removes the provider.
         For example, to remove the OpenStack network provider with identifier `1234`, send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/openstacknetworkproviders/1234
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18758,21 +19736,25 @@ class OpenstackNetworkProviderService(ExternalProviderService):
         """
         In order to test connectivity for external provider we need
         to run following request where 123 is an id of a provider.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/externalhostproviders/123/testconnectivity
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the test should be performed asynchronously.
+        `async_` \n
+        Indicates if the test should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18804,13 +19786,13 @@ class OpenstackNetworkProviderService(ExternalProviderService):
         Updates the provider.
         For example, to update `provider_name`, `requires_authentication`, `url`, `tenant_name` and `type` properties,
         for the OpenStack network provider with identifier `1234`, send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/openstacknetworkproviders/1234
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <openstack_network_provider>
           <name>ovn-network-provider</name>
           <requires_authentication>false</requires_authentication>
@@ -18818,18 +19800,22 @@ class OpenstackNetworkProviderService(ExternalProviderService):
           <tenant_name>oVirt</tenant_name>
           <type>external</type>
         </openstack_network_provider>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `provider`:: The provider to update.
+        `provider` \n
+        The provider to update.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -18936,18 +19922,24 @@ class OpenstackNetworkProvidersService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of providers to return. If not specified all the providers are returned.
+        `max` \n
+        Sets the maximum number of providers to return. If not specified all the providers are returned.
 
-        `search`:: A query string used to restrict the returned OpenStack network providers.
+        `search` \n
+        A query string used to restrict the returned OpenStack network providers.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19018,16 +20010,21 @@ class OpenstackNetworksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of networks to return. If not specified all the networks are returned.
+        `max` \n
+        Sets the maximum number of networks to return. If not specified all the networks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19087,14 +20084,18 @@ class OpenstackSubnetService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19120,13 +20121,17 @@ class OpenstackSubnetService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19203,16 +20208,21 @@ class OpenstackSubnetsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of sub-networks to return. If not specified all the sub-networks are returned.
+        `max` \n
+        Sets the maximum number of sub-networks to return. If not specified all the sub-networks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19274,14 +20284,18 @@ class OpenstackVolumeAuthenticationKeyService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19307,13 +20321,17 @@ class OpenstackVolumeAuthenticationKeyService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19419,16 +20437,21 @@ class OpenstackVolumeAuthenticationKeysService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of keys to return. If not specified all the keys are returned.
+        `max` \n
+        Sets the maximum number of keys to return. If not specified all the keys are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19493,14 +20516,18 @@ class OpenstackVolumeProviderService(ExternalProviderService):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19553,17 +20580,22 @@ class OpenstackVolumeProviderService(ExternalProviderService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `force`:: Indicates if the operation should succeed, and the provider removed from the database,
+        `force` \n
+        Indicates if the operation should succeed, and the provider removed from the database,
         even if something fails during the operation.
         This parameter is optional, and the default value is `false`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19598,21 +20630,25 @@ class OpenstackVolumeProviderService(ExternalProviderService):
         """
         In order to test connectivity for external provider we need
         to run following request where 123 is an id of a provider.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/externalhostproviders/123/testconnectivity
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the test should be performed asynchronously.
+        `async_` \n
+        Indicates if the test should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19726,13 +20762,13 @@ class OpenstackVolumeProvidersService(Service):
         """
         Adds a new volume provider.
         For example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/openstackvolumeproviders
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <openstack_volume_provider>
           <name>mycinder</name>
           <url>https://mycinder.example.com:8776</url>
@@ -19744,7 +20780,7 @@ class OpenstackVolumeProvidersService(Service):
           <password>mypassword</password>
           <tenant_name>mytenant</tenant_name>
         </openstack_volume_provider>
-        ----
+        ```
 
 
         """
@@ -19776,18 +20812,24 @@ class OpenstackVolumeProvidersService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of providers to return. If not specified all the providers are returned.
+        `max` \n
+        Sets the maximum number of providers to return. If not specified all the providers are returned.
 
-        `search`:: A query string used to restrict the returned volume providers.
+        `search` \n
+        A query string used to restrict the returned volume providers.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19852,14 +20894,18 @@ class OpenstackVolumeTypeService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19912,16 +20958,21 @@ class OpenstackVolumeTypesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of volume types to return. If not specified all the volume types are returned.
+        `max` \n
+        Sets the maximum number of volume types to return. If not specified all the volume types are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -19981,14 +21032,18 @@ class OperatingSystemService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20041,16 +21096,21 @@ class OperatingSystemsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of networks to return. If not specified all the networks are returned.
+        `max` \n
+        Sets the maximum number of networks to return. If not specified all the networks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20110,14 +21170,18 @@ class PermissionService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20143,13 +21207,17 @@ class PermissionService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20202,29 +21270,33 @@ class PermitService(Service):
         Gets the information about the permit of the role.
         For example to retrieve the information about the permit with the id `456` of the role with the id `123`
         send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/roles/123/permits/456
-        ....
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <permit href="/ovirt-engine/api/roles/123/permits/456" id="456">
           <name>change_vm_cd</name>
           <administrative>false</administrative>
           <role href="/ovirt-engine/api/roles/123" id="123"/>
         </permit>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20250,20 +21322,24 @@ class PermitService(Service):
         """
         Removes the permit from the role.
         For example to remove the permit with id `456` from the role with id `123` send a request like this:
-        ....
+        ```
         DELETE /ovirt-engine/api/roles/123/permits/456
-        ....
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20314,29 +21390,33 @@ class PermitsService(Service):
         **kwargs
     ):
         """
-        Adds a permit to the role. The permit name can be retrieved from the xref:services-cluster_levels[cluster_levels] service.
+        Adds a permit to the role. The permit name can be retrieved from the `ClusterLevelsService` service.
         For example to assign a permit `create_vm` to the role with id `123` send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/roles/123/permits
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <permit>
           <name>create_vm</name>
         </permit>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `permit`:: The permit to add.
+        `permit` \n
+        The permit to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20361,11 +21441,11 @@ class PermitsService(Service):
         """
         List the permits of the role.
         For example to list the permits of the role with the id `123` send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/roles/123/permits
-        ....
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <permits>
           <permit href="/ovirt-engine/api/roles/123/permits/5" id="5">
             <name>change_vm_cd</name>
@@ -20378,22 +21458,27 @@ class PermitsService(Service):
             <role href="/ovirt-engine/api/roles/123" id="123"/>
           </permit>
         </permits>
-        ----
+        ```
         The order of the returned list of permits isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of permits to return. If not specified all the permits are returned.
+        `max` \n
+        Sets the maximum number of permits to return. If not specified all the permits are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20454,13 +21539,13 @@ class QosService(Service):
     ):
         """
         Get specified QoS in the data center.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/datacenters/123/qoss/123
-        ----
+        ```
         You will get response like this one below:
-        [source,xml]
-        ----
+        
+        ```xml
         <qos href="/ovirt-engine/api/datacenters/123/qoss/123" id="123">
           <name>123</name>
           <description>123</description>
@@ -20469,19 +21554,23 @@ class QosService(Service):
           <type>storage</type>
           <data_center href="/ovirt-engine/api/datacenters/123" id="123"/>
         </qos>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20506,21 +21595,25 @@ class QosService(Service):
     ):
         """
         Remove specified QoS from datacenter.
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/datacenters/123/qoss/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20551,20 +21644,20 @@ class QosService(Service):
     ):
         """
         Update the specified QoS in the dataCenter.
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/datacenters/123/qoss/123
-        ----
+        ```
         For example with curl:
-        [source]
-        ----
+        
+        ```
         curl -u admin@internal:123456 -X PUT -H "content-type: application/xml" -d \
         "<qos><name>321</name><description>321</description><max_iops>10</max_iops></qos>" \
         https://engine/ovirt-engine/api/datacenters/123/qoss/123
-        ----
+        ```
         You will receive response like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <qos href="/ovirt-engine/api/datacenters/123/qoss/123" id="123">
           <name>321</name>
           <description>321</description>
@@ -20573,18 +21666,22 @@ class QosService(Service):
           <type>storage</type>
           <data_center href="/ovirt-engine/api/datacenters/123" id="123"/>
         </qos>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `qos`:: Updated QoS object.
+        `qos` \n
+        Updated QoS object.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20637,13 +21734,13 @@ class QossService(Service):
     ):
         """
         Add a new QoS to the dataCenter.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/qoss
-        ----
+        ```
         The response will look as follows:
-        [source,xml]
-        ----
+        
+        ```xml
         <qos href="/ovirt-engine/api/datacenters/123/qoss/123" id="123">
           <name>123</name>
           <description>123</description>
@@ -20651,18 +21748,22 @@ class QossService(Service):
           <type>storage</type>
           <data_center href="/ovirt-engine/api/datacenters/123" id="123"/>
         </qos>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `qos`:: Added QoS object.
+        `qos` \n
+        Added QoS object.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20686,34 +21787,39 @@ class QossService(Service):
     ):
         """
         Returns the list of _quality of service_ configurations available in the data center.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/datacenter/123/qoss
-        ----
+        ```
         You will get response which will look like this:
-        [source, xml]
-        ----
+
+        ```xml
         <qoss>
           <qos href="/ovirt-engine/api/datacenters/123/qoss/1" id="1">...</qos>
           <qos href="/ovirt-engine/api/datacenters/123/qoss/2" id="2">...</qos>
           <qos href="/ovirt-engine/api/datacenters/123/qoss/3" id="3">...</qos>
         </qoss>
-        ----
+        ```
         The returned list of quality of service configurations isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of QoS descriptors to return. If not specified all the descriptors are returned.
+        `max` \n
+        Sets the maximum number of QoS descriptors to return. If not specified all the descriptors are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20778,12 +21884,12 @@ class QuotaService(Service):
         """
         Retrieves a quota.
         An example of retrieving a quota:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/datacenters/123/quotas/456
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <quota id="456">
           <name>myquota</name>
           <description>My new quota for virtual machines</description>
@@ -20792,19 +21898,23 @@ class QuotaService(Service):
           <storage_hard_limit_pct>20</storage_hard_limit_pct>
           <storage_soft_limit_pct>80</storage_soft_limit_pct>
         </quota>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20830,24 +21940,28 @@ class QuotaService(Service):
         """
         Delete a quota.
         An example of deleting a quota:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/datacenters/123-456/quotas/654-321
         -0472718ab224 HTTP/1.1
         Accept: application/xml
         Content-type: application/xml
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20879,21 +21993,19 @@ class QuotaService(Service):
         """
         Updates a quota.
         An example of updating a quota:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/datacenters/123/quotas/456
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <quota>
           <cluster_hard_limit_pct>30</cluster_hard_limit_pct>
           <cluster_soft_limit_pct>70</cluster_soft_limit_pct>
           <storage_hard_limit_pct>20</storage_hard_limit_pct>
           <storage_soft_limit_pct>80</storage_soft_limit_pct>
         </quota>
-        ----
-
-
+        ```
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -20971,14 +22083,18 @@ class QuotaClusterLimitService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21004,13 +22120,17 @@ class QuotaClusterLimitService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21092,16 +22212,21 @@ class QuotaClusterLimitsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of limits to return. If not specified all the limits are returned.
+        `max` \n
+        Sets the maximum number of limits to return. If not specified all the limits are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21161,14 +22286,18 @@ class QuotaStorageLimitService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21194,13 +22323,17 @@ class QuotaStorageLimitService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the update should be performed asynchronously.
+        `async_` \n
+        Indicates if the update should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21253,30 +22386,30 @@ class QuotaStorageLimitsService(Service):
         """
         Adds a storage limit to a specified quota.
         To create a 100GiB storage limit for all storage domains in a data center, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/quotas/456/quotastoragelimits
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <quota_storage_limit>
           <limit>100</limit>
         </quota_storage_limit>
-        ----
+        ```
         To create a 50GiB storage limit for a storage domain with the ID `000`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/quotas/456/quotastoragelimits
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <quota_storage_limit>
           <limit>50</limit>
           <storage_domain id="000"/>
         </quota_storage_limit>
-        ----
+        ```
 
 
         """
@@ -21307,16 +22440,21 @@ class QuotaStorageLimitsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of limits to return. If not specified, all the limits are returned.
+        `max` \n
+        Sets the maximum number of limits to return. If not specified, all the limits are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21379,17 +22517,17 @@ class QuotasService(Service):
         """
         Creates a new quota.
         An example of creating a new quota:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/datacenters/123/quotas
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <quota>
           <name>myquota</name>
           <description>My new quota for virtual machines</description>
         </quota>
-        ----
+        ```
 
 
         """
@@ -21420,16 +22558,21 @@ class QuotasService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of quota descriptors to return. If not specified all the descriptors are returned.
+        `max` \n
+        Sets the maximum number of quota descriptors to return. If not specified all the descriptors are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21489,13 +22632,13 @@ class RoleService(Service):
     ):
         """
         Get the role.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/roles/123
-        ----
+        ```
         You will receive XML response like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <role id="123">
           <name>MyRole</name>
           <description>MyRole description</description>
@@ -21503,19 +22646,23 @@ class RoleService(Service):
           <administrative>true</administrative>
           <mutable>false</mutable>
         </role>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21541,21 +22688,25 @@ class RoleService(Service):
         """
         Removes the role.
         To remove the role you need to know its id, then send request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/roles/{role_id}
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21586,33 +22737,37 @@ class RoleService(Service):
     ):
         """
         Updates a role. You are allowed to update `name`, `description` and `administrative` attributes after role is
-        created. Within this endpoint you can't add or remove roles permits you need to use
-        xref:services-permits[service] that manages permits of role.
+        created. Within this endpoint you can't add or remove roles permits you need to use `PermitsService`
+        that manages permits of role.
         For example to update role's `name`, `description` and `administrative` attributes send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/roles/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <role>
           <name>MyNewRoleName</name>
           <description>My new description of the role</description>
           <administrative>true</administrative>
         </group>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `role`:: Updated role.
+        `role` \n
+        Updated role.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21678,13 +22833,13 @@ class RolesService(Service):
         Create a new role. The role can be administrative or non-administrative and can have different permits.
         For example, to add the `MyRole` non-administrative role with permits to login and create virtual machines
         send a request like this (note that you have to pass permit id):
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/roles
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <role>
           <name>MyRole</name>
           <description>My custom role to create virtual machines</description>
@@ -21694,18 +22849,22 @@ class RolesService(Service):
             <permit id="1300"/>
           </permits>
         </group>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `role`:: Role that will be added.
+        `role` \n
+        Role that will be added.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21729,13 +22888,13 @@ class RolesService(Service):
     ):
         """
         List roles.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/roles
-        ----
+        ```
         You will receive response in XML like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <roles>
           <role id="123">
              <name>SuperUser</name>
@@ -21746,22 +22905,27 @@ class RolesService(Service):
           </role>
           ...
         </roles>
-        ----
+        ```
         The order of the returned list of roles isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of roles to return. If not specified all the roles are returned.
+        `max` \n
+        Sets the maximum number of roles to return. If not specified all the roles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21856,18 +23020,24 @@ class SchedulingPoliciesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of policies to return. If not specified all the policies are returned.
+        `max` \n
+        Sets the maximum number of policies to return. If not specified all the policies are returned.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21935,16 +23105,21 @@ class SchedulingPolicyService(Service):
         """
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -21974,13 +23149,17 @@ class SchedulingPolicyService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22091,16 +23270,21 @@ class SchedulingPolicyUnitService(Service):
         """
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22130,13 +23314,17 @@ class SchedulingPolicyUnitService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22195,18 +23383,24 @@ class SchedulingPolicyUnitsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of policy units to return. If not specified all the policy units are returned.
+        `max` \n
+        Sets the maximum number of policy units to return. If not specified all the policy units are returned.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22273,14 +23467,18 @@ class SnapshotService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22307,21 +23505,26 @@ class SnapshotService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `all_content`:: Indicates if all the attributes of the virtual machine snapshot should be included in the response.
-        By default the attribute `initialization.configuration.data` is excluded.
+        `all_content` \n
+        Indicates if all the attributes of the virtual machine snapshot should be included in the response.
+        By default the attribute `ovirtsdk4.types.Initialization.configuration` is excluded.
         For example, to retrieve the complete representation of the snapshot with id `456` of the virtual machine
         with id `123` send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/vms/123/snapshots/456?all_content=true
-        ....
+        ```
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22359,31 +23562,32 @@ class SnapshotService(Service):
         Restores a virtual machine snapshot.
         For example, to restore the snapshot with identifier `456` of virtual machine with identifier `123` send a
         request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/snapshots/456/restore
-        ----
+        ```
         With an empty `action` in the body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
         NOTE: Confirm that the commit operation is finished and the virtual machine is down before running the virtual machine.
 
 
         This method supports the following parameters:
 
-        `disks`:: Specify the disks included in the snapshot's restore.
+        `disks` \n
+        Specify the disks included in the snapshot's restore.
         For each disk parameter, it is also required to specify its `image_id`.
         For example, to restore a snapshot with an identifier `456` of a virtual machine with identifier `123`, including
         a disk with identifier `111` and `image_id` of `222`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/snapshots/456/restore
-        ----
+        ```
         Request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <disks>
             <disk id="111">
@@ -22391,15 +23595,19 @@ class SnapshotService(Service):
             </disk>
           </disks>
         </action>
-        ----
+        ```
 
-        `async_`:: Indicates if the restore should be performed asynchronously.
+        `async_` \n
+        Indicates if the restore should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22479,14 +23687,18 @@ class SnapshotCdromService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22539,16 +23751,21 @@ class SnapshotCdromsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of CDROMS to return. If not specified all the CDROMS are returned.
+        `max` \n
+        Sets the maximum number of CDROMS to return. If not specified all the CDROMS are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22608,14 +23825,18 @@ class SnapshotDiskService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22668,16 +23889,21 @@ class SnapshotDisksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of disks to return. If not specified all the disks are returned.
+        `max` \n
+        Sets the maximum number of disks to return. If not specified all the disks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22737,14 +23963,18 @@ class SnapshotNicService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22797,16 +24027,21 @@ class SnapshotNicsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of NICs to return. If not specified all the NICs are returned.
+        `max` \n
+        Sets the maximum number of NICs to return. If not specified all the NICs are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -22869,17 +24104,17 @@ class SnapshotsService(Service):
         """
         Creates a virtual machine snapshot.
         For example, to create a new snapshot for virtual machine `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/snapshots
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <snapshot>
           <description>My snapshot</description>
         </snapshot>
-        ----
+        ```
         For including only a sub-set of disks in the snapshots, add `disk_attachments` element to the
         request body. Note that disks which are not specified in `disk_attachments` element will not be a
         part of the snapshot. If an empty `disk_attachments` element is passed, the snapshot will include
@@ -22889,8 +24124,8 @@ class SnapshotsService(Service):
         This is used in order to restore a chain of images from backup. I.e. when restoring
         a disk with snapshots, the relevant `image_id` should be specified for each snapshot
         (so the identifiers of the disk snapshots are identical to the backup).
-        [source,xml]
-        ----
+        
+        ```xml
         <snapshot>
           <description>My snapshot</description>
           <disk_attachments>
@@ -22901,21 +24136,21 @@ class SnapshotsService(Service):
             </disk_attachment>
           </disk_attachments>
         </snapshot>
-        ----
+        ```
         [IMPORTANT]
         ====
-        When a snapshot is created, the default value for the
-        xref:types-snapshot-attributes-persist_memorystate[persist_memorystate] attribute is `true`. That means that the content of the memory of the virtual
-        machine will be included in the snapshot, and it also means that the virtual machine will be paused
-        for a longer time. That can negatively affect applications that are very sensitive to timing (NTP
+        When a snapshot is created, the default value for the `ovirtsdk4.types.Snapshot.persist_memorystate` attribute is `true`. 
+        That means that the content of the memory of the virtual machine will be included in the snapshot, 
+        and it also means that the virtual machine will be pausedfor a longer time. 
+        That can negatively affect applications that are very sensitive to timing (NTP
         servers, for example). In those cases make sure that you set the attribute to `false`:
-        [source,xml]
-        ----
+        
+        ```xml
         <snapshot>
           <description>My snapshot</description>
           <persist_memorystate>false</persist_memorystate>
         </snapshot>
-        ----
+        ```
         ====
 
 
@@ -22948,24 +24183,30 @@ class SnapshotsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of snapshots to return. If not specified all the snapshots are returned.
+        `max` \n
+        Sets the maximum number of snapshots to return. If not specified all the snapshots are returned.
 
-        `all_content`:: Indicates if all the attributes of the virtual machine snapshot should be included in the response.
-        By default the attribute `initialization.configuration.data` is excluded.
+        `all_content` \n
+        Indicates if all the attributes of the virtual machine snapshot should be included in the response.
+        By default the attribute `ovirtsdk4.types.Initialization.configuration` is excluded.
         For example, to retrieve the complete representation of the virtual machine with id `123` snapshots send a
         request like this:
-        ....
+        ```
         GET /ovirt-engine/api/vms/123/snapshots?all_content=true
-        ....
+        ```
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23029,14 +24270,18 @@ class SshPublicKeyService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23062,13 +24307,17 @@ class SshPublicKeyService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23100,9 +24349,7 @@ class SshPublicKeyService(Service):
         """
         Replaces the key with a new resource.
         IMPORTANT: Since version 4.4.8 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. Instead please use DELETE followed by xref:services-ssh_public_keys-methods-add[add operation].
-
-
+        compatibility. It will be removed in the future. Instead please use DELETE followed by `SshPublicKeysService.add`.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23177,23 +24424,23 @@ class SshPublicKeysService(Service):
         Returns a list of SSH public keys of the user.
         For example, to retrieve the list of SSH keys of user with identifier `123`,
         send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/users/123/sshpublickeys
-        ----
+        ```
         The result will be the following XML document:
-        [source,xml]
-        ----
+        
+        ```xml
         <ssh_public_keys>
           <ssh_public_key href="/ovirt-engine/api/users/123/sshpublickeys/456" id="456">
             <content>ssh-rsa ...</content>
             <user href="/ovirt-engine/api/users/123" id="123"/>
           </ssh_public_key>
         </ssh_public_keys>
-        ----
+        ```
         Or the following JSON object
-        [source,json]
-        ----
+
+        ```json
         {
           "ssh_public_key": [
             {
@@ -23207,22 +24454,27 @@ class SshPublicKeysService(Service):
             }
           ]
         }
-        ----
+        ```
         The order of the returned list of keys is not guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of keys to return. If not specified all the keys are returned.
+        `max` \n
+        Sets the maximum number of keys to return. If not specified all the keys are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23282,14 +24534,18 @@ class StatisticService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23337,13 +24593,13 @@ class StatisticsService(Service):
         Retrieves a list of statistics.
         For example, to retrieve the statistics for virtual machine `123` send a
         request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/vms/123/statistics
-        ----
+        ```
         The result will be like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <statistics>
           <statistic href="/ovirt-engine/api/vms/123/statistics/456" id="456">
             <name>memory.installed</name>
@@ -23360,15 +24616,15 @@ class StatisticsService(Service):
           </statistic>
           ...
         </statistics>
-        ----
+        ```
         Just a single part of the statistics can be retrieved by specifying its id at the end of the URI. That means:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/vms/123/statistics/456
-        ----
+        ```
         Outputs:
-        [source,xml]
-        ----
+        
+        ```xml
         <statistic href="/ovirt-engine/api/vms/123/statistics/456" id="456">
           <name>memory.installed</name>
           <description>Total memory configured</description>
@@ -23382,22 +24638,27 @@ class StatisticsService(Service):
           </values>
           <vm href="/ovirt-engine/api/vms/123" id="123"/>
         </statistic>
-        ----
+        ```
         The order of the returned list of statistics isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of statistics to return. If not specified all the statistics are returned.
+        `max` \n
+        Sets the maximum number of statistics to return. If not specified all the statistics are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23463,34 +24724,40 @@ class StepService(MeasurableService):
         Marks an external step execution as ended.
         For example, to terminate a step with identifier `456` which belongs to a `job` with identifier `123` send the
         following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/jobs/123/steps/456/end
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <force>true</force>
           <succeeded>true</succeeded>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `force`:: Indicates if the step should be forcibly terminated.
+        `force` \n
+        Indicates if the step should be forcibly terminated.
 
-        `succeeded`:: Indicates if the step should be marked as successfully finished or as failed.
+        `succeeded` \n
+        Indicates if the step should be marked as successfully finished or as failed.
         This parameter is optional, and the default value is `true`.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23523,13 +24790,13 @@ class StepService(MeasurableService):
     ):
         """
         Retrieves a step.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/jobs/123/steps/456
-        ----
+        ```
         You will receive response in XML like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <step href="/ovirt-engine/api/jobs/123/steps/456" id="456">
           <actions>
             <link href="/ovirt-engine/api/jobs/123/steps/456/end" rel="end"/>
@@ -23543,19 +24810,23 @@ class StepService(MeasurableService):
           <type>validating</type>
           <job href="/ovirt-engine/api/jobs/123" id="123"/>
         </step>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23613,23 +24884,23 @@ class StepsService(Service):
         Add an external step to an existing job or to an existing step.
         For example, to add a step to `job` with identifier `123` send the
         following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/jobs/123/steps
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <step>
           <description>Validating</description>
           <start_time>2016-12-12T23:07:26.605+02:00</start_time>
           <status>started</status>
           <type>validating</type>
         </step>
-        ----
+        ```
         The response should look like:
-        [source,xml]
-        ----
+        
+        ```xml
         <step href="/ovirt-engine/api/jobs/123/steps/456" id="456">
           <actions>
             <link href="/ovirt-engine/api/jobs/123/steps/456/end" rel="end"/>
@@ -23643,18 +24914,22 @@ class StepsService(Service):
           <type>validating</type>
           <job href="/ovirt-engine/api/jobs/123" id="123"/>
         </step>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `step`:: Step that will be added.
+        `step` \n
+        Step that will be added.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23678,13 +24953,13 @@ class StepsService(Service):
     ):
         """
         Retrieves the representation of the steps.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/job/123/steps
-        ----
+        ```
         You will receive response in XML like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <steps>
           <step href="/ovirt-engine/api/jobs/123/steps/456" id="456">
             <actions>
@@ -23701,22 +24976,27 @@ class StepsService(Service):
           </step>
           ...
         </steps>
-        ----
+        ```
         The order of the returned list of steps isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of steps to return. If not specified all the steps are returned.
+        `max` \n
+        Sets the maximum number of steps to return. If not specified all the steps are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23779,14 +25059,15 @@ class StorageService(Service):
         """
         This method supports the following parameters:
 
-        `report_status`:: Indicates if the status of the LUNs in the storage should be checked.
+        `report_status` \n
+        Indicates if the status of the LUNs in the storage should be checked.
         Checking the status of the LUN is an heavy weight operation and
         this data is not always needed by the user.
         This parameter will give the option to not perform the status check of the LUNs.
         The default is `true` for backward compatibility.
         Here an example with the LUN status :
-        [source,xml]
-        ----
+        
+        ```xml
         <host_storage id="360014051136c20574f743bdbd28177fd">
           <logical_units>
             <logical_unit id="360014051136c20574f743bdbd28177fd">
@@ -23803,10 +25084,10 @@ class StorageService(Service):
           <type>iscsi</type>
           <host id="8bb5ade5-e988-4000-8b93-dbfc6717fe50"/>
         </host_storage>
-        ----
+        ```
         Here an example without the LUN status :
-        [source,xml]
-        ----
+        
+        ```xml
         <host_storage id="360014051136c20574f743bdbd28177fd">
           <logical_units>
             <logical_unit id="360014051136c20574f743bdbd28177fd">
@@ -23822,16 +25103,20 @@ class StorageService(Service):
           <type>iscsi</type>
           <host id="8bb5ade5-e988-4000-8b93-dbfc6717fe50"/>
         </host_storage>
-        ----
+        ```
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23893,16 +25178,21 @@ class StorageDomainService(Service):
 
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23938,15 +25228,20 @@ class StorageDomainService(Service):
 
         This method supports the following parameters:
 
-        `host`:: Indicates the data center's host.
+        `host` \n
+        Indicates the data center's host.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -23980,33 +25275,37 @@ class StorageDomainService(Service):
         In order to do so the data stored on the provided logical units will be moved to other logical units of the
         storage domain and only then they will be reduced from the storage domain.
         For example, in order to reduce two logical units from a storage domain send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/storageDomains/123/reduceluns
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
          <action>
            <logical_units>
              <logical_unit id="1IET_00010001"/>
              <logical_unit id="1IET_00010002"/>
            </logical_units>
          </action>
-        ----
-         Note that this operation is only applicable to block storage domains (i.e., storage domains with the
-         xref:types-storage_type[storage type] of iSCSI or FCP).
+        ```
+        Note that this operation is only applicable to block storage domains (i.e., storage domains with the
+        `ovirtsdk4.types.StorageType` of iSCSI or FCP).
 
 
         This method supports the following parameters:
 
-        `logical_units`:: The logical units that need to be reduced from the storage domain.
+        `logical_units` \n
+        The logical units that need to be reduced from the storage domain.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24037,33 +25336,38 @@ class StorageDomainService(Service):
         This action forces a rescan of the provided LUNs and
         updates the database with the new size, if required.
         For example, in order to refresh the size of two LUNs send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/storageDomains/262b056b-aede-40f1-9666-b883eff59d40/refreshluns
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
          <action>
            <logical_units>
              <logical_unit id="1IET_00010001"/>
              <logical_unit id="1IET_00010002"/>
            </logical_units>
          </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `logical_units`:: The LUNs that need to be refreshed.
+        `logical_units` \n
+        The LUNs that need to be refreshed.
 
-        `async_`:: Indicates if the refresh should be performed asynchronously.
+        `async_` \n
+        Indicates if the refresh should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24108,40 +25412,47 @@ class StorageDomainService(Service):
 
         This method supports the following parameters:
 
-        `host`:: Indicates which host should be used to remove the storage domain.
+        `host` \n
+        Indicates which host should be used to remove the storage domain.
         This parameter is mandatory, except if the `destroy` parameter is included and its value is `true`, in that
         case the `host` parameter will be ignored.
         The value should contain the name or the identifier of the host. For example, to use the host named `myhost`
         to remove the storage domain with identifier `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/storageDomains/123?host=myhost
-        ----
+        ```
 
-        `format`:: Indicates if the actual storage should be formatted, removing all the metadata from the underlying LUN or
+        `format` \n
+        Indicates if the actual storage should be formatted, removing all the metadata from the underlying LUN or
         directory:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/storageDomains/123?format=true
-        ----
+        ```
         This parameter is optional, and the default value is `false`.
 
-        `destroy`:: Indicates if the operation should succeed, and the storage domain removed from the database, even if the
+        `destroy` \n
+        Indicates if the operation should succeed, and the storage domain removed from the database, even if the
         storage is not accessible.
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/storageDomains/123?destroy=true
-        ----
+        ```
         This parameter is optional, and the default value is `false`.
         When the value of `destroy` is `true` the `host` parameter will be ignored.
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24183,35 +25494,39 @@ class StorageDomainService(Service):
     ):
         """
         Updates a storage domain.
-        Not all of the xref:types-storage_domain[StorageDomain]'s attributes are updatable after creation. Those that can be
+        Not all of the `ovirtsdk4.types.StorageDomain`'s attributes are updatable after creation. Those that can be
         updated are: `name`, `description`, `comment`, `warning_low_space_indicator`, `critical_space_action_blocker` and
         `wipe_after_delete.` (Note that changing the `wipe_after_delete` attribute will not change the wipe after delete
         property of disks that already exist).
         To update the `name` and `wipe_after_delete` attributes of a storage domain with an identifier `123`, send a
         request as follows:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/storageDomains/123
-        ----
+        ```
         With a request body as follows:
-        [source,xml]
-        ----
+        
+        ```xml
         <storage_domain>
           <name>data2</name>
           <wipe_after_delete>true</wipe_after_delete>
         </storage_domain>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `storage_domain`:: The updated storage domain.
+        `storage_domain` \n
+        The updated storage domain.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24258,13 +25573,17 @@ class StorageDomainService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the `OVF_STORE` update should be performed asynchronously.
+        `async_` \n
+        Indicates if the `OVF_STORE` update should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24401,16 +25720,21 @@ class StorageDomainContentDiskService(Service):
         """
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24470,22 +25794,29 @@ class StorageDomainContentDisksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of disks to return. If not specified all the disks are returned.
+        `max` \n
+        Sets the maximum number of disks to return. If not specified all the disks are returned.
 
-        `search`:: A query string used to restrict the returned disks.
+        `search` \n
+        A query string used to restrict the returned disks.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24540,8 +25871,8 @@ class StorageDomainDiskService(MeasurableService):
     IMPORTANT: Since version 4.2 of the engine this service is intended only to list disks available in the storage
     domain, and to register unregistered disks. All the other operations, like copying a disk, moving a disk, etc, have
     been deprecated and will be removed in the future. To perform those operations
-    use the xref:services-disks[service that manages all the disks of the system]
-    or the xref:services-disk[service that manages a specific disk].
+    use the `DisksService` service that manages all the disks of the system,
+    or the `DiskService` service that manages a specific disk.
 
     """
 
@@ -24562,21 +25893,26 @@ class StorageDomainDiskService(MeasurableService):
         """
         Copies a disk to the specified storage domain.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To copy a disk use the xref:services-disk-methods-copy[copy]
+        compatibility. It will be removed in the future. To copy a disk use the `DiskService.copy`
         operation of the service that manages that disk.
 
 
         This method supports the following parameters:
 
-        `disk`:: Description of the resulting disk.
+        `disk` \n
+        Description of the resulting disk.
 
-        `storage_domain`:: The storage domain where the new disk will be created.
+        `storage_domain` \n
+        The storage domain where the new disk will be created.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24604,19 +25940,23 @@ class StorageDomainDiskService(MeasurableService):
         """
         Exports a disk to an export storage domain.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To export a disk use the xref:services-disk-methods-export[export]
+        compatibility. It will be removed in the future. To export a disk use the `DiskService.export` 
         operation of the service that manages that disk.
 
 
         This method supports the following parameters:
 
-        `storage_domain`:: The export storage domain where the disk should be exported to.
+        `storage_domain` \n
+        The export storage domain where the disk should be exported to.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24645,14 +25985,18 @@ class StorageDomainDiskService(MeasurableService):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24680,23 +26024,28 @@ class StorageDomainDiskService(MeasurableService):
         """
         Moves a disk to another storage domain.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To move a disk use the xref:services-disk-methods-move[move]
+        compatibility. It will be removed in the future. To move a disk use the `DiskService.move`
         operation of the service that manages that disk.
-
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain where the disk will be moved to.
+        `storage_domain` \n
+        The storage domain where the disk will be moved to.
 
-        `async_`:: Indicates if the move should be performed asynchronously.
+        `async_` \n
+        Indicates if the move should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24736,13 +26085,17 @@ class StorageDomainDiskService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24771,7 +26124,7 @@ class StorageDomainDiskService(MeasurableService):
         """
         Removes a disk.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To remove a disk use the xref:services-disk-methods-remove[remove]
+        compatibility. It will be removed in the future. To remove a disk use the `DiskService.remove`
         operation of the service that manages that disk.
 
 
@@ -24796,7 +26149,7 @@ class StorageDomainDiskService(MeasurableService):
         """
         Sparsify the disk.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To remove a disk use the xref:services-disk-methods-remove[remove]
+        compatibility. It will be removed in the future. To remove a disk use the `DiskService.remove`
         operation of the service that manages that disk.
 
 
@@ -24823,19 +26176,23 @@ class StorageDomainDiskService(MeasurableService):
         """
         Updates the disk.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To update a disk use the
-        xref:services-disk-methods-update[update] operation of the service that manages that disk.
+        compatibility. It will be removed in the future. To update a disk use the `DiskService.update` operation 
+        of the service that manages that disk.
 
 
         This method supports the following parameters:
 
-        `disk`:: The update to apply to the disk.
+        `disk` \n
+        The update to apply to the disk.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24902,21 +26259,23 @@ class StorageDomainDisksService(Service):
         """
         Adds or registers a disk.
         IMPORTANT: Since version 4.2 of the {engine-name} this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To add a new disk use the xref:services-disks-methods-add[add]
+        compatibility. It will be removed in the future. To add a new disk use the `DisksService.add`
         operation of the service that manages the disks of the system. To register an unregistered disk use the
-        xref:services-attached_storage_domain_disk-methods-register[register] operation of the service that manages
-        that disk.
-
+        `AttachedStorageDomainDiskService.register` operation of the service that manages that disk.
 
         This method supports the following parameters:
 
-        `disk`:: The disk to add or register.
+        `disk` \n
+        The disk to add or register.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -24950,25 +26309,31 @@ class StorageDomainDisksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of disks to return. If not specified, all the disks are returned.
+        `max` \n
+        Sets the maximum number of disks to return. If not specified, all the disks are returned.
 
-        `unregistered`:: Indicates whether to retrieve a list of registered or unregistered disks in the storage domain.
+        `unregistered` \n
+        Indicates whether to retrieve a list of registered or unregistered disks in the storage domain.
         To get a list of unregistered disks in the storage domain the call should indicate the unregistered flag.
         For example, to get a list of unregistered disks the REST API call should look like this:
-        ....
+        ```
         GET /ovirt-engine/api/storagedomains/123/disks?unregistered=true
-        ....
+        ```
         The default value of the unregistered flag is `false`.
         The request only applies to storage domains that are attached.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25034,14 +26399,18 @@ class StorageDomainServerConnectionService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25070,13 +26439,17 @@ class StorageDomainServerConnectionService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25155,16 +26528,21 @@ class StorageDomainServerConnectionsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of connections to return. If not specified all the connections are returned.
+        `max` \n
+        Sets the maximum number of connections to return. If not specified all the connections are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25225,14 +26603,18 @@ class StorageDomainTemplateService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25264,13 +26646,12 @@ class StorageDomainTemplateService(Service):
         """
         Action to import a template from an export storage domain.
         For example, to import the template `456` from the storage domain `123` send the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/storagedomains/123/templates/456/import
-        ----
+        ```
         With the following request body:
-        [source, xml]
-        ----
+        ```xml
         <action>
           <storage_domain>
             <name>myexport</name>
@@ -25279,7 +26660,7 @@ class StorageDomainTemplateService(Service):
             <name>mycluster</name>
           </cluster>
         </action>
-        ----
+        ```
         If you register an entity without specifying the cluster ID or name,
         the cluster name from the entity's OVF will be used (unless the register request also includes the
         cluster mapping).
@@ -25287,17 +26668,22 @@ class StorageDomainTemplateService(Service):
 
         This method supports the following parameters:
 
-        `clone`:: Use the optional `clone` parameter to generate new UUIDs for the imported template and its entities.
+        `clone` \n
+        Use the optional `clone` parameter to generate new UUIDs for the imported template and its entities.
         You can import a template with the `clone` parameter set to `false` when importing a template
         from an export domain, with templates that were exported by a different {product-name} environment.
 
-        `async_`:: Indicates if the import should be performed asynchronously.
+        `async_` \n
+        Indicates if the import should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25350,29 +26736,36 @@ class StorageDomainTemplateService(Service):
 
         This method supports the following parameters:
 
-        `allow_partial_import`:: Indicates whether a template is allowed to be registered with only some of its disks.
+        `allow_partial_import` \n
+        Indicates whether a template is allowed to be registered with only some of its disks.
         If this flag is `true`, the system will not fail in the validation process if an image is not found, but
         instead it will allow the template to be registered without the missing disks. This is mainly used during
         registration of a template when some of the storage domains are not available. The default value is `false`.
 
-        `vnic_profile_mappings`:: Deprecated attribute describing mapping rules for virtual NIC profiles that will be applied during the import\register process.
+        `vnic_profile_mappings` \n
+        Deprecated attribute describing mapping rules for virtual NIC profiles that will be applied during the import\register process.
         WARNING: Please note that this attribute has been deprecated since version 4.2.1 of the engine, and preserved only for backward
         compatibility. It will be removed in the future. To specify `vnic_profile_mappings` use the `vnic_profile_mappings`
-        attribute inside the xref:types-registration_configuration[RegistrationConfiguration] type.
+        attribute inside the `ovirtsdk4.types.RegistrationConfiguration` type.
 
-        `registration_configuration`:: This parameter describes how the template should be
+        `registration_configuration` \n
+        This parameter describes how the template should be
         registered.
         This parameter is optional. If the parameter is not specified, the template
         will be registered with the same configuration that
         it had in the original environment where it was created.
 
-        `async_`:: Indicates if the registration should be performed asynchronously.
+        `async_` \n
+        Indicates if the registration should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25416,13 +26809,17 @@ class StorageDomainTemplateService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25490,25 +26887,31 @@ class StorageDomainTemplatesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of templates to return. If not specified all the templates are returned.
+        `max` \n
+        Sets the maximum number of templates to return. If not specified all the templates are returned.
 
-        `unregistered`:: Indicates whether to retrieve a list of registered or unregistered templates which contain disks on the storage domain.
+        `unregistered` \n
+        Indicates whether to retrieve a list of registered or unregistered templates which contain disks on the storage domain.
         To get a list of unregistered templates the call should indicate the unregistered flag.
         For example, to get a list of unregistered templates the REST API call should look like this:
-        ....
+        ```
         GET /ovirt-engine/api/storagedomains/123/templates?unregistered=true
-        ....
+        ```
         The default value of the unregisterd flag is `false`.
         The request only apply to storage domains that are attached.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25574,14 +26977,18 @@ class StorageDomainVmService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25613,13 +27020,13 @@ class StorageDomainVmService(Service):
         """
         Imports a virtual machine from an export storage domain.
         For example, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/storagedomains/123/vms/456/import
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain>
             <name>mydata</name>
@@ -25628,10 +27035,10 @@ class StorageDomainVmService(Service):
             <name>mycluster</name>
           </cluster>
         </action>
-        ----
+        ```
         To import a virtual machine as a new entity add the `clone` parameter:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain>
             <name>mydata</name>
@@ -25644,11 +27051,11 @@ class StorageDomainVmService(Service):
             <name>myvm</name>
           </vm>
         </action>
-        ----
+        ```
         Include an optional `disks` parameter to choose which disks to import. For example, to import the disks
         of the template that have the identifiers `123` and `456` send the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <cluster>
             <name>mycluster</name>
@@ -25661,7 +27068,7 @@ class StorageDomainVmService(Service):
             <disk id="456"/>
           </disks>
         </action>
-        ----
+        ```
         If you register an entity without specifying the cluster ID or name,
         the cluster name from the entity's OVF will be used (unless the register request also includes the
         cluster mapping).
@@ -25669,7 +27076,8 @@ class StorageDomainVmService(Service):
 
         This method supports the following parameters:
 
-        `clone`:: Indicates if the identifiers of the imported virtual machine
+        `clone` \n
+        Indicates if the identifiers of the imported virtual machine
         should be regenerated.
         By default when a virtual machine is imported the identifiers
         are preserved. This means that the same virtual machine can't
@@ -25677,19 +27085,24 @@ class StorageDomainVmService(Service):
         unique. To allow importing the same machine multiple times set
         this parameter to `true`, as the default is `false`.
 
-        `collapse_snapshots`:: Indicates of the snapshots of the virtual machine that is imported
+        `collapse_snapshots` \n
+        Indicates of the snapshots of the virtual machine that is imported
         should be collapsed, so that the result will be a virtual machine
         without snapshots.
         This parameter is optional, and if it isn't explicitly specified the
         default value is `false`.
 
-        `async_`:: Indicates if the import should be performed asynchronously.
+        `async_` \n
+        Indicates if the import should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25738,35 +27151,43 @@ class StorageDomainVmService(Service):
         """
         This method supports the following parameters:
 
-        `allow_partial_import`:: Indicates whether a virtual machine is allowed to be registered with only some of its disks.
+        `allow_partial_import` \n
+        Indicates whether a virtual machine is allowed to be registered with only some of its disks.
         If this flag is `true`, the engine will not fail in the validation process if an image is not found, but
         instead it will allow the virtual machine to be registered without the missing disks. This is mainly used
         during registration of a virtual machine when some of the storage domains are not available. The default
         value is `false`.
 
-        `vnic_profile_mappings`:: Deprecated attribute describing mapping rules for virtual NIC profiles that will be applied during the import\register process.
+        `vnic_profile_mappings` \n
+        Deprecated attribute describing mapping rules for virtual NIC profiles that will be applied during the import\register process.
         WARNING: Please note that this attribute has been deprecated since version 4.2.1 of the engine, and preserved only for backward
         compatibility. It will be removed in the future. To specify `vnic_profile_mappings` use the `vnic_profile_mappings`
-        attribute inside the xref:types-registration_configuration[RegistrationConfiguration] type.
+        attribute inside the `ovirtsdk4.types.RegistrationConfiguration` type.
 
-        `reassign_bad_macs`:: Indicates if the problematic MAC addresses should be re-assigned during the import process by the engine.
+        `reassign_bad_macs` \n
+        Indicates if the problematic MAC addresses should be re-assigned during the import process by the engine.
         A MAC address would be considered as a problematic one if one of the following is true:
         - It conflicts with a MAC address that is already allocated to a virtual machine in the target environment.
         - It's out of the range of the target MAC address pool.
 
-        `registration_configuration`:: This parameter describes how the virtual machine should be
+        `registration_configuration` \n
+        This parameter describes how the virtual machine should be
         registered.
         This parameter is optional. If the parameter is not specified, the virtual
         machine will be registered with the same configuration that
         it had in the original environment where it was created.
 
-        `async_`:: Indicates if the registration should be performed asynchronously.
+        `async_` \n
+        Indicates if the registration should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25810,21 +27231,25 @@ class StorageDomainVmService(Service):
         """
         Deletes a virtual machine from an export storage domain.
         For example, to delete the virtual machine `456` from the storage domain `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/storagedomains/123/vms/456
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25899,14 +27324,18 @@ class StorageDomainVmDiskAttachmentService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -25958,14 +27387,18 @@ class StorageDomainVmDiskAttachmentsService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26010,13 +27443,13 @@ class StorageDomainVmsService(Service):
     Lists the virtual machines of an export storage domain.
     For example, to retrieve the virtual machines that are available in the storage domain with identifier `123` send the
     following request:
-    [source]
-    ----
+    
+    ```
     GET /ovirt-engine/api/storagedomains/123/vms
-    ----
+    ```
     This will return the following response body:
-    [source,xml]
-    ----
+    
+    ```xml
     <vms>
       <vm id="456" href="/api/storagedomains/123/vms/456">
         <name>vm1</name>
@@ -26027,12 +27460,10 @@ class StorageDomainVmsService(Service):
         </actions>
       </vm>
     </vms>
-    ----
+    ```
     Virtual machines and templates in these collections have a similar representation to their counterparts in the
-    top-level xref:types-vm[Vm] and xref:types-template[Template] collections, except they also contain a
-    xref:types-storage_domain[StorageDomain] reference and an xref:services-storage_domain_vm-methods-import[import]
-    action.
-
+    top-level `ovirtsdk4.types.Vm` and `ovirtsdk4.types.Template` collections, except they also contain a
+    `ovirtsdk4.types.StorageDomain` reference and an `StorageDomainVmService.import_` action.
     """
 
     def __init__(self, connection, path):
@@ -26056,27 +27487,33 @@ class StorageDomainVmsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of virtual machines to return. If not specified all the virtual machines are
+        `max` \n
+        Sets the maximum number of virtual machines to return. If not specified all the virtual machines are
         returned.
 
-        `unregistered`:: Indicates whether to retrieve a list of registered or unregistered virtual machines which
+        `unregistered` \n
+        Indicates whether to retrieve a list of registered or unregistered virtual machines which
         contain disks on the storage domain.
         To get a list of unregistered virtual machines the call should indicate the unregistered flag.
         For example, to get a list of unregistered virtual machines the REST API call should look like this:
-        ....
+        ```
         GET /ovirt-engine/api/storagedomains/123/vms?unregistered=true
-        ....
+        ```
         The default value of the unregisterd flag is `false`.
         The request only apply to storage domains that are attached.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26142,20 +27579,20 @@ class StorageDomainsService(Service):
     ):
         """
         Adds a new storage domain.
-        Creation of a new xref:types-storage_domain[StorageDomain] requires the `name`, `type`, `host`, and `storage`
+        Creation of a new `ovirtsdk4.types.StorageDomain` requires the `name`, `type`, `host`, and `storage`
         attributes. Identify the `host` attribute with the `id` or `name` attributes. In {product-name} 3.6 and
         later you can enable the wipe after delete option by default on the storage domain. To configure this, specify
         `wipe_after_delete` in the POST request. This option can be edited after the domain is created, but doing so will
         not change the wipe after delete property of disks that already exist.
         To add a new storage domain with specified `name`, `type`, `storage.type`, `storage.address`, and `storage.path`,
         and using a host with an id `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/storageDomains
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <storage_domain>
           <name>mydata</name>
           <type>data</type>
@@ -26168,10 +27605,10 @@ class StorageDomainsService(Service):
             <name>myhost</name>
           </host>
         </storage_domain>
-        ----
+        ```
         To create a new NFS ISO storage domain send a request like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <storage_domain>
           <name>myisos</name>
           <type>iso</type>
@@ -26184,10 +27621,10 @@ class StorageDomainsService(Service):
             <name>myhost</name>
           </host>
         </storage_domain>
-        ----
+        ```
         To create a new iSCSI storage domain send a request like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <storage_domain>
           <name>myiscsi</name>
           <type>data</type>
@@ -26202,18 +27639,22 @@ class StorageDomainsService(Service):
             <name>myhost</name>
           </host>
         </storage_domain>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain to add.
+        `storage_domain` \n
+        The storage domain to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26240,13 +27681,17 @@ class StorageDomainsService(Service):
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain to add.
+        `storage_domain` \n
+        The storage domain to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26273,13 +27718,17 @@ class StorageDomainsService(Service):
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain to add.
+        `storage_domain` \n
+        The storage domain to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26306,13 +27755,17 @@ class StorageDomainsService(Service):
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain to add.
+        `storage_domain` \n
+        The storage domain to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26339,13 +27792,17 @@ class StorageDomainsService(Service):
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain to add.
+        `storage_domain` \n
+        The storage domain to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26378,24 +27835,32 @@ class StorageDomainsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of storage domains to return. If not specified, all the storage domains are returned.
+        `max` \n
+        Sets the maximum number of storage domains to return. If not specified, all the storage domains are returned.
 
-        `search`:: A query string used to restrict the returned storage domains.
+        `search` \n
+        A query string used to restrict the returned storage domains.
 
-        `case_sensitive`:: Indicates if the search should be performed taking case into account.
+        `case_sensitive` \n
+        Indicates if the search should be performed taking case into account.
         The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case, set it to `false`.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26439,13 +27904,17 @@ class StorageDomainsService(Service):
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain to add.
+        `storage_domain` \n
+        The storage domain to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26499,14 +27968,18 @@ class StorageServerConnectionService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26690,22 +28163,27 @@ class StorageServerConnectionService(Service):
 
         This method supports the following parameters:
 
-        `host`:: The name or identifier of the host from which the connection would be unmounted (disconnected). If not
+        `host` \n
+        The name or identifier of the host from which the connection would be unmounted (disconnected). If not
         provided, no host will be disconnected.
         For example, to use the host with identifier `456` to delete the storage connection with identifier `123`
         send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/storageconnections/123?host=456
-        ----
+        ```
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26741,30 +28219,28 @@ class StorageServerConnectionService(Service):
         """
         Updates the storage connection.
         For example, to change the address of an NFS storage server, send a request like this:
-        [source,xml]
-        ----
+        ```
         PUT /ovirt-engine/api/storageconnections/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <storage_connection>
           <address>mynewnfs.example.com</address>
         </storage_connection>
-        ----
+        ```
         To change the connection of an iSCSI storage server, send a request like this:
-        [source,xml]
-        ----
+        ```
         PUT /ovirt-engine/api/storageconnections/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <storage_connection>
           <port>3260</port>
           <target>iqn.2017-01.com.myhost:444</target>
         </storage_connection>
-        ----
+        ```
 
 
         """
@@ -26859,14 +28335,18 @@ class StorageServerConnectionExtensionService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26892,13 +28372,17 @@ class StorageServerConnectionExtensionService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -26930,19 +28414,19 @@ class StorageServerConnectionExtensionService(Service):
         """
         Update a storage server connection extension for the given host.
         To update the storage connection `456` of host `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/hosts/123/storageconnectionextensions/456
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <storage_connection_extension>
           <target>iqn.2016-01.com.example:mytarget</target>
           <username>myuser</username>
           <password>mypassword</password>
         </storage_connection_extension>
-        ----
+        ```
 
 
         """
@@ -26998,19 +28482,19 @@ class StorageServerConnectionExtensionsService(Service):
         The extension lets the user define credentials for an iSCSI target for a specific host. For example to use
         `myuser` and `mypassword` as the credentials when connecting to the iSCSI target from host `123` send a request
         like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts/123/storageconnectionextensions
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <storage_connection_extension>
           <target>iqn.2016-01.com.example:mytarget</target>
           <username>myuser</username>
           <password>mypassword</password>
         </storage_connection_extension>
-        ----
+        ```
 
 
         """
@@ -27041,16 +28525,21 @@ class StorageServerConnectionExtensionsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of extensions to return. If not specified all the extensions are returned.
+        `max` \n
+        Sets the maximum number of extensions to return. If not specified all the extensions are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -27112,13 +28601,13 @@ class StorageServerConnectionsService(Service):
         Creates a new storage connection.
         For example, to create a new storage connection for the NFS server `mynfs.example.com` and NFS share
         `/export/mydata` send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/storageconnections
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <storage_connection>
           <type>nfs</type>
           <address>mynfs.example.com</address>
@@ -27127,7 +28616,7 @@ class StorageServerConnectionsService(Service):
             <name>myhost</name>
           </host>
         </storage_connection>
-        ----
+        ```
 
 
         """
@@ -27206,16 +28695,21 @@ class StorageServerConnectionsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of connections to return. If not specified all the connections are returned.
+        `max` \n
+        Sets the maximum number of connections to return. If not specified all the connections are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -27387,13 +28881,13 @@ class SystemService(Service):
         """
         Returns basic information describing the API, like the product name, the version number and a summary of the
         number of relevant objects.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api
-        ----
+        ```
         We get following response:
-        [source,xml]
-        ----
+        
+        ```xml
         <api>
           <link rel="capabilities" href="/api/capabilities"/>
           <link rel="clusters" href="/api/clusters"/>
@@ -27453,7 +28947,7 @@ class SystemService(Service):
           </summary>
           <time>2016-09-14T12:00:48.132+02:00</time>
         </api>
-        ----
+        ```
         The entry point provides a user with links to the collections in a
         virtualization environment. The `rel` attribute of each collection link
         provides a reference point for each link.
@@ -27463,14 +28957,18 @@ class SystemService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -27496,13 +28994,17 @@ class SystemService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the reload should be performed asynchronously.
+        `async_` \n
+        Indicates if the reload should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -27932,13 +29434,13 @@ class SystemOptionService(Service):
         """
         Get the values of specific configuration option.
         For example to retrieve the values of configuration option `MigrationPolicies` send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/options/MigrationPolicies
-        ----
+        ```
         The response to that request will be the following:
-        [source,xml]
-        ----
+        
+        ```xml
         <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
         <system_option href="/ovirt-engine/api/options/MigrationPolicies" id="MigrationPolicies">
             <name>MigrationPolicies</name>
@@ -27969,7 +29471,7 @@ class SystemOptionService(Service):
                 </system_option_value>
             </values>
         </system_option>
-        ----
+        ```
         NOTE: The appropriate permissions are required to query configuration options. Some options can be queried
         only by users with administrator permissions.
         [IMPORTANT]
@@ -27977,25 +29479,24 @@ class SystemOptionService(Service):
         There is NO backward compatibility and no guarantee about the names or values of the options. Options may be
         removed and their meaning can be changed at any point.
         We strongly discourage the use of this service for applications other than the ones that are released
-        simultaneously with the engine. Usage by other applications is not supported. Therefore there will be no
-        documentation listing accessible configuration options.
+        simultaneously with the engine. Usage by other applications is not supported. Therefore there will be no documentation listing accessible configuration options.
         ====
-
 
         This method supports the following parameters:
 
-        `version`:: Optional version parameter that specifies that only particular version of the configuration option
+        `version` \n
+        Optional version parameter that specifies that only particular version of the configuration option
         should be returned.
         If this parameter isn't used then all the versions will be returned.
         For example, to get the value of the `MigrationPolicies` option but only for version `4.2` send
         a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/options/MigrationPolicies?version=4.2
-        ----
+        ```
         The response to that request will be like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <system_option href="/ovirt-engine/api/options/MigrationPolicies" id="MigrationPolicies">
             <name>MigrationPolicies</name>
             <values>
@@ -28005,13 +29506,16 @@ class SystemOptionService(Service):
                 </system_option_value>
             </values>
         </system_option>
-        ----
+        ```
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28096,60 +29600,64 @@ class SystemPermissionsService(AssignedPermissionsService):
         Assign a new permission to a user or group for specific entity.
         For example, to assign the `UserVmManager` role to the virtual machine with id `123` to the user with id `456`
         send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/vms/123/permissions
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <permission>
           <role>
             <name>UserVmManager</name>
           </role>
           <user id="456"/>
         </permission>
-        ----
+        ```
         To assign the `SuperUser` role to the system to the user with id `456` send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/permissions
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <permission>
           <role>
             <name>SuperUser</name>
           </role>
           <user id="456"/>
         </permission>
-        ----
+        ```
         If you want to assign permission to the group instead of the user please replace the `user` element with the
         `group` element with proper `id` of the group. For example to assign the `UserRole` role to the cluster with
         id `123` to the group with id `789` send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/clusters/123/permissions
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <permission>
           <role>
             <name>UserRole</name>
           </role>
           <group id="789"/>
         </permission>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28176,13 +29684,17 @@ class SystemPermissionsService(AssignedPermissionsService):
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28209,13 +29721,17 @@ class SystemPermissionsService(AssignedPermissionsService):
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28242,13 +29758,17 @@ class SystemPermissionsService(AssignedPermissionsService):
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28275,13 +29795,17 @@ class SystemPermissionsService(AssignedPermissionsService):
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28305,11 +29829,11 @@ class SystemPermissionsService(AssignedPermissionsService):
         """
         List all the permissions of the specific entity.
         For example to list all the permissions of the cluster with id `123` send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/clusters/123/permissions
-        ....
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <permissions>
           <permission id="456">
             <cluster id="123"/>
@@ -28322,20 +29846,24 @@ class SystemPermissionsService(AssignedPermissionsService):
             <group id="127"/>
           </permission>
         </permissions>
-        ----
+        ```
         The order of the returned permissions isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28364,13 +29892,17 @@ class SystemPermissionsService(AssignedPermissionsService):
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28397,13 +29929,17 @@ class SystemPermissionsService(AssignedPermissionsService):
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28430,13 +29966,17 @@ class SystemPermissionsService(AssignedPermissionsService):
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28463,13 +30003,17 @@ class SystemPermissionsService(AssignedPermissionsService):
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28496,13 +30040,17 @@ class SystemPermissionsService(AssignedPermissionsService):
 
         This method supports the following parameters:
 
-        `permission`:: The permission.
+        `permission` \n
+        The permission.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28561,28 +30109,32 @@ class TagService(Service):
         """
         Gets the information about the tag.
         For example to retrieve the information about the tag with the id `123` send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/tags/123
-        ....
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <tag href="/ovirt-engine/api/tags/123" id="123">
           <name>root</name>
           <description>root</description>
         </tag>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28608,20 +30160,24 @@ class TagService(Service):
         """
         Removes the tag from the system.
         For example to remove the tag with id `123` send a request like this:
-        ....
+        ```
         DELETE /ovirt-engine/api/tags/123
-        ....
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28653,37 +30209,41 @@ class TagService(Service):
         """
         Updates the tag entity.
         For example to update parent tag to tag with id `456` of the tag with id `123` send a request like this:
-        ....
+        ```
         PUT /ovirt-engine/api/tags/123
-        ....
+        ```
         With request body like:
-        [source,xml]
-        ----
+        
+        ```xml
         <tag>
           <parent id="456"/>
         </tag>
-        ----
+        ```
         You may also specify a tag name instead of id. For example to update parent tag to tag with name `mytag`
         of the tag with id `123` send a request like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <tag>
           <parent>
             <name>mytag</name>
           </parent>
         </tag>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `tag`:: The updated tag.
+        `tag` \n
+        The updated tag.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28737,39 +30297,43 @@ class TagsService(Service):
         """
         Add a new tag to the system.
         For example, to add new tag with name `mytag` to the system send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/tags
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <tag>
           <name>mytag</name>
         </tag>
-        ----
+        ```
         NOTE: The root tag is a special pseudo-tag assumed as the default parent tag if no parent tag is specified.
         The root tag cannot be deleted nor assigned a parent tag.
         To create new tag with specific parent tag send a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <tag>
           <name>mytag</name>
           <parent>
             <name>myparenttag</name>
           </parent>
         </tag>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `tag`:: The added tag.
+        `tag` \n
+        The added tag.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28794,11 +30358,11 @@ class TagsService(Service):
         """
         List the tags in the system.
         For example to list the full hierarchy of the tags in the system send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/tags
-        ....
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <tags>
           <tag href="/ovirt-engine/api/tags/222" id="222">
             <name>root2</name>
@@ -28815,28 +30379,33 @@ class TagsService(Service):
             <description>root</description>
           </tag>
         </tags>
-        ----
+        ```
         In the previous XML output you can see the following hierarchy of the tags:
-        ....
+        ```
         root:        (id: 111)
           - root2    (id: 222)
             - root3  (id: 333)
-        ....
+        ```
         The order of the returned list of tags isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of tags to return. If not specified all the tags are returned.
+        `max` \n
+        Sets the maximum number of tags to return. If not specified all the tags are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28909,27 +30478,27 @@ class TemplateService(Service):
         """
         Exports a template to the data center export domain.
         For example, send the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/templates/123/export
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain id="456"/>
           <exclusive>true<exclusive/>
         </action>
-        ----
+        ```
         Since version 4.2 of the engine it is also possible to export a template as a virtual appliance (OVA).
         For example, to export template `123` as an OVA file named `myvm.ova` that is placed in the directory `/home/ovirt/` on host `myhost`:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/templates/123/export
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <host>
             <name>myhost</name>
@@ -28937,22 +30506,27 @@ class TemplateService(Service):
           <directory>/home/ovirt</directory>
           <filename>myvm.ova</filename>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `exclusive`:: Indicates if the existing templates with the same name should be overwritten.
+        `exclusive` \n
+        Indicates if the existing templates with the same name should be overwritten.
         The export action reports a failed action if a template of the same name exists in the destination domain.
         Set this parameter to `true` to change this behavior and overwrite any existing template.
 
-        `storage_domain`:: Specifies the destination export storage domain.
+        `storage_domain` \n
+        Specifies the destination export storage domain.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -28984,16 +30558,21 @@ class TemplateService(Service):
 
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29022,21 +30601,25 @@ class TemplateService(Service):
     ):
         """
         Removes a virtual machine template.
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/templates/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the removal should be performed asynchronously.
+        `async_` \n
+        Indicates if the removal should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29071,17 +30654,22 @@ class TemplateService(Service):
 
         This method supports the following parameters:
 
-        `exclusive`:: Indicates if the existing templates with the same name should be overwritten.
+        `exclusive` \n
+        Indicates if the existing templates with the same name should be overwritten.
         The export action reports a failed action if a template of the same name exists in the destination domain.
         Set this parameter to `true` to change this behavior and overwrite any existing template.
 
-        `storage_domain`:: Specifies the destination export storage domain.
+        `storage_domain` \n
+        Specifies the destination export storage domain.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29116,25 +30704,33 @@ class TemplateService(Service):
 
         This method supports the following parameters:
 
-        `host`:: The host to generate the OVA file on.
+        `host` \n
+        The host to generate the OVA file on.
 
-        `directory`:: An absolute path of a directory on the host to generate the OVA file in.
+        `directory` \n
+        An absolute path of a directory on the host to generate the OVA file in.
 
-        `filename`:: The name of the OVA file.
+        `filename` \n
+        The name of the OVA file.
         This is an optional parameter. If it is not specified, the name of the OVA file is determined according
-        to the name of the template. It will conform to the following pattern: "<template name>.ova".
+        to the name of the template. It will conform to the following pattern: template_name.ova.
 
-        `exclusive`:: Indicates if the existing templates with the same name should be overwritten.
+        `exclusive` \n
+        Indicates if the existing templates with the same name should be overwritten.
         The export action reports a failed action if a template of the same name exists in the destination domain.
         Set this parameter to `true` to change this behavior and overwrite any existing template.
 
-        `storage_domain`:: Specifies the destination export storage domain.
+        `storage_domain` \n
+        Specifies the destination export storage domain.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29171,27 +30767,27 @@ class TemplateService(Service):
         The `name`, `description`, `type`, `memory`, `cpu`, `topology`, `os`, `high_availability`, `display`,
         `stateless`, `usb`, and `timezone` elements can be updated after a template has been created.
         For example, to update a template so that it has 1 GiB of memory send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/templates/123
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <template>
           <memory>1073741824</memory>
         </template>
-        ----
+        ```
         The `version_name` name attribute is the only one that can be updated within the `version` attribute used for
         template versions:
-        [source,xml]
-        ----
+        
+        ```xml
         <template>
           <version>
             <version_name>mytemplate_2</version_name>
           </version>
         </template>
-        ----
+        ```
 
 
         """
@@ -29335,22 +30931,26 @@ class TemplateCdromService(Service):
         """
         Returns the information about this CD-ROM device.
         For example, to get information about the CD-ROM device of template `123` send a request like:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/templates/123/cdroms/
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29403,16 +31003,21 @@ class TemplateCdromsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of CD-ROMs to return. If not specified all the CD-ROMs are returned.
+        `max` \n
+        Sets the maximum number of CD-ROMs to return. If not specified all the CD-ROMs are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29479,15 +31084,20 @@ class TemplateDiskService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the copy should be performed asynchronously.
+        `async_` \n
+        Indicates if the copy should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29523,15 +31133,20 @@ class TemplateDiskService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the export should be performed asynchronously.
+        `async_` \n
+        Indicates if the export should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29565,14 +31180,18 @@ class TemplateDiskService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29598,13 +31217,17 @@ class TemplateDiskService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29659,14 +31282,18 @@ class TemplateDiskAttachmentService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29695,21 +31322,25 @@ class TemplateDiskAttachmentService(Service):
         disk on other storage domains.
         A storage domain has to be specified to determine which of the copies should be removed (template disks can
         have copies on multiple storage domains).
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/templates/{template:id}/diskattachments/{attachment:id}?storage_domain=072fbaa1-08f3-4a40-9f34-a5ca22dd1d74
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `storage_domain`:: Specifies the identifier of the storage domain the image to be removed resides on.
+        `storage_domain` \n
+        Specifies the identifier of the storage domain the image to be removed resides on.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29743,8 +31374,7 @@ class TemplateDiskAttachmentService(Service):
 class TemplateDiskAttachmentsService(Service):
     """
     This service manages the set of disks attached to a template. Each attached disk is represented by a
-    xref:types-disk_attachment[DiskAttachment].
-
+    `ovirtsdk4.types.DiskAttachment`.
     """
 
     def __init__(self, connection, path):
@@ -29766,14 +31396,18 @@ class TemplateDiskAttachmentsService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29837,16 +31471,21 @@ class TemplateDisksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of disks to return. If not specified all the disks are returned.
+        `max` \n
+        Sets the maximum number of disks to return. If not specified all the disks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29909,14 +31548,18 @@ class TemplateGraphicsConsoleService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -29945,13 +31588,17 @@ class TemplateGraphicsConsoleService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30031,16 +31678,21 @@ class TemplateGraphicsConsolesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of consoles to return. If not specified all the consoles are returned.
+        `max` \n
+        Sets the maximum number of consoles to return. If not specified all the consoles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30105,14 +31757,18 @@ class TemplateMediatedDeviceService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30141,13 +31797,17 @@ class TemplateMediatedDeviceService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30180,8 +31840,8 @@ class TemplateMediatedDeviceService(Service):
         Updates the information about the mediated device.
         You can update the information using `specParams` element.
         For example, to update a mediated device, send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/templates/123/mediateddevices/00000000-0000-0000-0000-000000000000
         <vm_mediated_device>
           <spec_params>
@@ -30191,10 +31851,10 @@ class TemplateMediatedDeviceService(Service):
             </property>
           </spec_params>
         </vm_mediated_device>
-        ----
+        ```
         with response body:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm_mediated_device href="/ovirt-engine/api/templates/123/mediateddevices/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000">
           <template href="/ovirt-engine/api/templates/123" id="123"/>
           <spec_params>
@@ -30204,21 +31864,25 @@ class TemplateMediatedDeviceService(Service):
             </property>
           </spec_params>
         </vm_mediated_device>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `devices`:: The information about the mediated device.
+        `devices` \n
+        The information about the mediated device.
         The request data must contain `specParams` properties.
         The response data contains complete information about the
         updated mediated device.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30301,17 +31965,22 @@ class TemplateMediatedDevicesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of mediated devices to return.
+        `max` \n
+        Sets the maximum number of mediated devices to return.
         If not specified all the mediated devices are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30373,14 +32042,18 @@ class TemplateNicService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30406,13 +32079,17 @@ class TemplateNicService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30525,16 +32202,21 @@ class TemplateNicsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of NICs to return. If not specified all the NICs are returned.
+        `max` \n
+        Sets the maximum number of NICs to return. If not specified all the NICs are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30594,14 +32276,18 @@ class TemplateWatchdogService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30627,13 +32313,17 @@ class TemplateWatchdogService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30746,16 +32436,21 @@ class TemplateWatchdogsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of watchdogs to return. If not specified all the watchdogs are returned.
+        `max` \n
+        Sets the maximum number of watchdogs to return. If not specified all the watchdogs are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30822,21 +32517,21 @@ class TemplatesService(Service):
         This requires the `name` and `vm` elements. To identify the virtual machine use the `vm.id` or `vm.name`
         attributes. For example, to create a template from a virtual machine with the identifier `123` send a request
         like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/templates
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <template>
           <name>mytemplate</name>
           <vm id="123"/>
         </template>
-        ----
+        ```
         Since version 4.3, in order to create virtual machine template from a snapshot send a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <template>
           <name>mytemplate</name>
           <vm id="123">
@@ -30845,15 +32540,15 @@ class TemplatesService(Service):
             </snapshots>
           </vm>
         </template>
-        ----
+        ```
         The disks of the template can be customized, making some of their characteristics different from the disks of the
-        original virtual machine. To do so use the `vm.disk_attachments` attribute, specifying the identifier of the disk
+        original virtual machine. To do so use the `ovirtsdk4.types.Vm.disk_attachments` attribute, specifying the identifier of the disk
         of the original virtual machine and the characteristics that you want to change. For example, if the original
         virtual machine has a disk with the identifier `456`, and, for that disk, you want to change the name to `mydisk`
-        the format to xref:types-disk_format[_Copy On Write_] and make it xref:types-disk[sparse], send a request body like
+        the format to `ovirtsdk4.types.DiskFormat.COW` and make it `ovirtsdk4.types.Disk.sparse`, send a request body like
         this:
-        [source,xml]
-        ----
+
+        ```xml
         <template>
           <name>mytemplate</name>
           <vm id="123">
@@ -30868,13 +32563,13 @@ class TemplatesService(Service):
             </disk_attachments>
           </vm>
         </template>
-        ----
+        ```
         The template can be created as a sub-version of an existing template. This requires the `name` and `vm` attributes
         for the new template, and the `base_template` and `version_name` attributes for the new template version. The
         `base_template` and `version_name` attributes must be specified within a `version` section enclosed in the
         `template` section. Identify the virtual machine with the `id` or `name` attributes.
-        [source,xml]
-        ----
+        
+        ```xml
         <template>
           <name>mytemplate</name>
           <vm id="123"/>
@@ -30883,13 +32578,12 @@ class TemplatesService(Service):
             <version_name>mytemplate_001</version_name>
           </version>
         </template>
-        ----
+        ```
         The destination storage domain of the template can be customized, in one of two ways:
         1. Globally, at the request level. The request must list the desired disk attachments to be created on the
         storage domain. If the disk attachments are not listed, the global storage domain parameter will be ignored.
-        +
-        [source,xml]
-        ----
+
+        ```xml
         <template>
           <name>mytemplate</name>
           <storage_domain id="123"/>
@@ -30904,12 +32598,11 @@ class TemplatesService(Service):
             </disk_attachments>
           </vm>
         </template>
-        ----
+        ```
         2. Per each disk attachment. Specify the desired storage domain for each disk attachment.
         Specifying the global storage definition will override the storage domain per disk attachment specification.
-        +
-        [source,xml]
-        ----
+
+        ```xml
         <template>
           <name>mytemplate</name>
           <vm id="123">
@@ -30926,18 +32619,21 @@ class TemplatesService(Service):
             </disk_attachments>
           </vm>
         </template>
-        ----
-
+        ```
 
         This method supports the following parameters:
 
-        `template`:: The information about the template or template version.
+        `template` \n
+        The information about the template or template version.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -30974,13 +32670,17 @@ class TemplatesService(Service):
 
         This method supports the following parameters:
 
-        `template`:: The information about the template or template version.
+        `template` \n
+        The information about the template or template version.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31017,13 +32717,17 @@ class TemplatesService(Service):
 
         This method supports the following parameters:
 
-        `template`:: The information about the template or template version.
+        `template` \n
+        The information about the template or template version.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31060,13 +32764,17 @@ class TemplatesService(Service):
 
         This method supports the following parameters:
 
-        `template`:: The information about the template or template version.
+        `template` \n
+        The information about the template or template version.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31102,34 +32810,42 @@ class TemplatesService(Service):
         """
         Returns the list of virtual machine templates.
         For example:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/templates
-        ----
+        ```
         Will return the list of virtual machines and virtual machine templates.
         The order of the returned list of templates is not guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of templates to return. If not specified, all the templates are returned.
+        `max` \n
+        Sets the maximum number of templates to return. If not specified, all the templates are returned.
 
-        `search`:: A query string used to restrict the returned templates.
+        `search` \n
+        A query string used to restrict the returned templates.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31202,14 +32918,18 @@ class UnmanagedNetworkService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31235,13 +32955,17 @@ class UnmanagedNetworkService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31297,16 +33021,21 @@ class UnmanagedNetworksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of networks to return. If not specified all the networks are returned.
+        `max` \n
+        Sets the maximum number of networks to return. If not specified all the networks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31352,9 +33081,7 @@ class UserService(Service):
     """
     A service to manage a user in the system.
     Use this service to either get users details or remove users.
-    In order to add new users please use
-    xref:services-users[users].
-
+    In order to add new users please use `UsersService`.
     """
 
     def __init__(self, connection, path):
@@ -31378,12 +33105,12 @@ class UserService(Service):
         """
         Gets the system user information.
         Usage:
-        ....
+        ```
         GET /ovirt-engine/api/users/1234
-        ....
+        ```
         Will return the user information:
-        [source,xml]
-        ----
+        
+        ```xml
         <user href="/ovirt-engine/api/users/1234" id="1234">
           <name>admin</name>
           <link href="/ovirt-engine/api/users/1234/sshpublickeys" rel="sshpublickeys"/>
@@ -31401,19 +33128,23 @@ class UserService(Service):
             <name>domain-authz</name>
           </domain>
         </user>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31439,20 +33170,24 @@ class UserService(Service):
         """
         Removes the system user.
         Usage:
-        ....
+        ```
         DELETE /ovirt-engine/api/users/1234
-        ....
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31484,13 +33219,13 @@ class UserService(Service):
         Updates information about the user.
         Only the `user_options` field can be updated.
         For example, to update user options:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/users/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <user>
            <user_options>
               <property>
@@ -31499,12 +33234,9 @@ class UserService(Service):
               </property>
            </user_options>
         </user>
-        ----
+        ```
         IMPORTANT: Since version 4.4.5 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. Please use the xref:services-user_option[options]
-        endpoint instead.
-
-
+        compatibility. It will be removed in the future. Please use the `UserOptionService` endpoint instead.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31611,19 +33343,19 @@ class UserOptionService(Service):
         """
         Returns a user profile property of type JSON.
         Example request(for user with identifier `123` and option with identifier `456`):
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/users/123/options/456
-        ----
+        ```
         The result will be the following XML document:
-        [source,xml]
-        ----
+        
+        ```xml
           <user_option href="/ovirt-engine/api/users/123/options/456" id="456">
             <name>SomeName</name>
             <content>["any", "JSON"]</content>
             <user href="/ovirt-engine/api/users/123" id="123"/>
           </user_option>
-        ----
+        ```
 
 
         """
@@ -31647,10 +33379,10 @@ class UserOptionService(Service):
         """
         Deletes an existing property of type JSON.
         Example request(for user with identifier `123` and option with identifier `456`):
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/users/123/options/456
-        ----
+        ```
 
 
         """
@@ -31695,18 +33427,18 @@ class UserOptionsService(Service):
         """
         Adds a new user profile property of type JSON.
         Example request(for user with identifier `123`):
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/users/123/options
-        ----
+        ```
         Payload:
-        [source,xml]
-        ----
+        
+        ```xml
           <user_option>
             <name>SomeName</name>
             <content>["any", "JSON"]</content>
           </user_option>
-        ----
+        ```
 
 
         """
@@ -31731,13 +33463,13 @@ class UserOptionsService(Service):
         """
         Returns a list of user profile properties of type JSON.
         Example request(for user with identifier `123`):
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/users/123/options
-        ----
+        ```
         The result will be the following XML document:
-        [source,xml]
-        ----
+        
+        ```xml
         <user_options>
           <user_option href="/ovirt-engine/api/users/123/options/456" id="456">
             <name>SomeName</name>
@@ -31745,7 +33477,7 @@ class UserOptionsService(Service):
             <user href="/ovirt-engine/api/users/123" id="123"/>
           </user_option>
         </user_options>
-        ----
+        ```
 
 
         """
@@ -31804,27 +33536,27 @@ class UsersService(Service):
         Add user from a directory service.
         For example, to add the `myuser` user from the `myextension-authz` authorization provider send a request
         like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/users
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <user>
           <user_name>myuser@myextension-authz</user_name>
           <domain>
             <name>myextension-authz</name>
           </domain>
         </user>
-        ----
+        ```
         In case you are working with Active Directory you have to pass user principal name (UPN) as `username`, followed
-        by authorization provider name. Due to link:https://bugzilla.redhat.com/1147900[bug 1147900] you need to provide
+        by authorization provider name. Due to link:https://bugzilla.redhat.com/1147900 you need to provide
         also `principal` parameter set to UPN of the user.
         For example, to add the user with UPN `myuser@mysubdomain.mydomain.com` from the `myextension-authz`
         authorization provider send a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <user>
           <principal>myuser@mysubdomain.mydomain.com</principal>
           <user_name>myuser@mysubdomain.mydomain.com@myextension-authz</user_name>
@@ -31832,7 +33564,7 @@ class UsersService(Service):
             <name>myextension-authz</name>
           </domain>
         </user>
-        ----
+        ```
 
 
         """
@@ -31861,12 +33593,12 @@ class UsersService(Service):
         """
         List all the users in the system.
         Usage:
-        ....
+        ```
         GET /ovirt-engine/api/users
-        ....
+        ```
         Will return the list of users:
-        [source,xml]
-        ----
+        
+        ```xml
         <users>
           <user href="/ovirt-engine/api/users/1234" id="1234">
             <name>admin</name>
@@ -31883,28 +33615,35 @@ class UsersService(Service):
             </domain>
           </user>
         </users>
-        ----
+        ```
         The order of the returned list of users isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of users to return. If not specified all the users are returned.
+        `max` \n
+        Sets the maximum number of users to return. If not specified all the users are returned.
 
-        `search`:: A query string used to restrict the returned users.
+        `search` \n
+        A query string used to restrict the returned users.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -31971,14 +33710,18 @@ class VirtualFunctionAllowedNetworkService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32004,13 +33747,17 @@ class VirtualFunctionAllowedNetworkService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32087,16 +33834,21 @@ class VirtualFunctionAllowedNetworksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of networks to return. If not specified all the networks are returned.
+        `max` \n
+        Sets the maximum number of networks to return. If not specified all the networks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32176,34 +33928,39 @@ class VmService(MeasurableService):
         """
         Apply an automatic CPU and NUMA configuration on the VM.
         IMPORTANT: Since version 4.5 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. Instead please use PUT followed by xref:services-vm-methods-update[update operation].
+        compatibility. It will be removed in the future. Instead please use PUT followed by `VmService.update`.
         An example for a request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/autopincpuandnumanodes
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <optimize_cpu_settings>true</optimize_cpu_settings>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `optimize_cpu_settings`:: Specifies how the auto CPU and NUMA configuration is applied.
+        `optimize_cpu_settings` \n
+        Specifies how the auto CPU and NUMA configuration is applied.
         If set to true, will adjust the CPU topology to fit the VM pinned host hardware.
         Otherwise, it will use the VM CPU topology.
 
-        `async_`:: Indicates if the detach action should be performed asynchronously.
+        `async_` \n
+        Indicates if the detach action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32234,27 +33991,31 @@ class VmService(MeasurableService):
     ):
         """
         This operation stops any migration of a virtual machine to another physical host.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/cancelmigration
-        ----
+        ```
         The cancel migration action does not take any action specific parameters;
         therefore, the request body should contain an empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the migration should cancelled asynchronously.
+        `async_` \n
+        Indicates if the migration should cancelled asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32287,18 +34048,24 @@ class VmService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the clone should be performed asynchronously.
+        `async_` \n
+        Indicates if the clone should be performed asynchronously.
 
-        `discard_snapshots`:: Use the `discard_snapshots` parameter when the virtual machine should be clone with its
+        `discard_snapshots` \n
+        Use the `discard_snapshots` parameter when the virtual machine should be clone with its
         snapshots collapsed. Default is true.
 
-        `storage_domain`:: The storage domain on which the virtual machines disks will be copied to.
+        `storage_domain` \n
+        The storage domain on which the virtual machines disks will be copied to.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32333,18 +34100,21 @@ class VmService(MeasurableService):
     ):
         """
         Permanently restores the virtual machine to the state of the previewed snapshot.
-        See the xref:services-vm-methods-preview_snapshot[preview_snapshot] operation for details.
-
+        See the `VmService.preview_snapshot` operation for details.
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the snapshots should be committed asynchronously.
+        `async_` \n
+        Indicates if the snapshots should be committed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32373,27 +34143,31 @@ class VmService(MeasurableService):
     ):
         """
         Detaches a virtual machine from a pool.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/detach
-        ----
+        ```
         The detach action does not take any action specific parameters; therefore, the request body should contain an
         empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the detach action should be performed asynchronously.
+        `async_` \n
+        Indicates if the detach action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32427,13 +34201,13 @@ class VmService(MeasurableService):
         Exports the virtual machine.
         A virtual machine can be exported to an export domain.
         For example, to export virtual machine `123` to the export domain `myexport`:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/export
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain>
             <name>myexport</name>
@@ -32441,16 +34215,16 @@ class VmService(MeasurableService):
           <exclusive>true</exclusive>
           <discard_snapshots>true</discard_snapshots>
         </action>
-        ----
+        ```
         Since version 4.2 of the engine it is also possible to export a virtual machine as a virtual appliance (OVA).
         For example, to export virtual machine `123` as an OVA file named `myvm.ova` that is placed in the directory `/home/ovirt/` on host `myhost`:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/export
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <host>
             <name>myhost</name>
@@ -32458,27 +34232,34 @@ class VmService(MeasurableService):
           <directory>/home/ovirt</directory>
           <filename>myvm.ova</filename>
         </action>
-        ----
+        ```
         NOTE: Confirm that the export operation has completed before attempting any actions on the export domain.
 
 
         This method supports the following parameters:
 
-        `discard_snapshots`:: Use the `discard_snapshots` parameter when the virtual machine should be exported with all of its
+        `discard_snapshots` \n
+        Use the `discard_snapshots` parameter when the virtual machine should be exported with all of its
         snapshots collapsed.
 
-        `exclusive`:: Use the `exclusive` parameter when the virtual machine should be exported even if another copy of
+        `exclusive` \n
+        Use the `exclusive` parameter when the virtual machine should be exported even if another copy of
         it already exists in the export domain (override).
 
-        `storage_domain`:: The (export) storage domain to export the virtual machine to.
+        `storage_domain` \n
+        The (export) storage domain to export the virtual machine to.
 
-        `async_`:: Indicates if the export should be performed asynchronously.
+        `async_` \n
+        Indicates if the export should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32517,25 +34298,29 @@ class VmService(MeasurableService):
         a running virtual machine. Normally, this is done automatically by the manager, but this must be executed
         manually with the API for virtual machines using OpenStack Volume (Cinder) disks.
         Example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/freezefilesystems
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the freeze should be performed asynchronously.
+        `async_` \n
+        Indicates if the freeze should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32572,54 +34357,62 @@ class VmService(MeasurableService):
 
         This method supports the following parameters:
 
-        `next_run`:: Indicates if the returned result describes the virtual machine as it is currently running or if describes
+        `next_run` \n
+        Indicates if the returned result describes the virtual machine as it is currently running or if describes
         the virtual machine with the modifications that have already been performed but that will only come into
         effect when the virtual machine is restarted. By default the value is `false`.
         If the parameter is included in the request, but without a value, it is assumed that the value is `true`. The
         the following request:
-        [source]
-        ----
+        
+        ```
         GET /vms/{vm:id};next_run
-        ----
+        ```
         Is equivalent to using the value `true`:
-        [source]
-        ----
+        
+        ```
         GET /vms/{vm:id};next_run=true
-        ----
+        ```
 
-        `all_content`:: Indicates if all of the attributes of the virtual machine should be included in the response.
+        `all_content` \n
+        Indicates if all of the attributes of the virtual machine should be included in the response.
         By default the following attributes are excluded:
         - `console`
-        - `initialization.configuration.data` - The OVF document describing the virtual machine.
+        - `ovirtsdk4.types.Initialization.configuration` - The OVF document describing the virtual machine.
         - `rng_source`
         - `soundcard`
         - `virtio_scsi`
         For example, to retrieve the complete representation of the virtual machine '123':
-        ....
+        ```
         GET /ovirt-engine/api/vms/123?all_content=true
-        ....
+        ```
         NOTE: These attributes are not included by default as they reduce performance. These attributes are seldom used
         and require additional queries to the database. Only use this parameter when required as it will reduce performance.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `ovf_as_ova`:: Indicates if the results should expose the OVF as it appears in OVA files of that VM. The OVF document
+        `ovf_as_ova` \n
+        Indicates if the results should expose the OVF as it appears in OVA files of that VM. The OVF document
         describing the virtual machine. This parameter will work only when all_content=True is set.
-        The OVF will be presented in `initialization.configuration.data`.
+        The OVF will be presented in `ovirtsdk4.types.Initialization.configuration`.
         For example:
-        [source]
-        ----
+        
+        ```
         GET /vms/{vm:id}?all_content=true&ovf_as_ova=true
-        ----
+        ```
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32665,26 +34458,30 @@ class VmService(MeasurableService):
         Users require the appropriate user permissions for the virtual machine in order to access the virtual machine
         from an external console.
         For example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/logon
-        ----
+        ```
         Request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the logon should be performed asynchronously.
+        `async_` \n
+        Indicates if the logon should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32716,29 +34513,34 @@ class VmService(MeasurableService):
         Sets the global maintenance mode on the hosted engine virtual machine.
         This action has no effect on other virtual machines.
         Example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/maintenance
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <action>
           <maintenance_enabled>true<maintenance_enabled/>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `maintenance_enabled`:: Indicates if global maintenance should be enabled or disabled.
+        `maintenance_enabled` \n
+        Indicates if global maintenance should be enabled or disabled.
 
-        `async_`:: Indicates if the global maintenance action should be performed asynchronously.
+        `async_` \n
+        Indicates if the global maintenance action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32774,44 +34576,52 @@ class VmService(MeasurableService):
         """
         Migrates a virtual machine to another physical host.
         Example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/migrate
-        ----
+        ```
         To specify a specific host to migrate the virtual machine to:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <host id="2ab5e1da-b726-4274-bbf7-0a42b16a0fc3"/>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `cluster`:: Specifies the cluster the virtual machine should migrate to. This is an optional parameter. By default, the
+        `cluster` \n
+        Specifies the cluster the virtual machine should migrate to. This is an optional parameter. By default, the
         virtual machine is migrated to another host within the same cluster.
         WARNING: Live migration to another cluster is not supported. Strongly consider the target cluster's hardware
         architecture and network architecture before attempting a migration.
 
-        `force`:: Specifies that the virtual machine should migrate even if the virtual machine is defined as non-migratable.
+        `force` \n
+        Specifies that the virtual machine should migrate even if the virtual machine is defined as non-migratable.
         This is an optional parameter. By default, it is set to `false`.
 
-        `host`:: Specifies a specific host that the virtual machine should migrate to. This is an optional parameter. By default,
+        `host` \n
+        Specifies a specific host that the virtual machine should migrate to. This is an optional parameter. By default,
         the {engine-name} automatically selects a default host for migration within the same cluster. If an API user
         requires a specific host, the user can specify the host with either an `id` or `name` parameter.
 
-        `migrate_vms_in_affinity_closure`:: Migrate also all other virtual machines in positive enforcing affinity groups with this virtual machine,
+        `migrate_vms_in_affinity_closure` \n
+        Migrate also all other virtual machines in positive enforcing affinity groups with this virtual machine,
         that are running on the same host.
         The default value is `false`.
 
-        `async_`:: Indicates if the migration should be performed asynchronously.
+        `async_` \n
+        Indicates if the migration should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32855,23 +34665,22 @@ class VmService(MeasurableService):
         Temporarily restores the virtual machine to the state of a snapshot.
         The snapshot is indicated with the `snapshot.id` parameter. It is restored temporarily, so that the content can
         be inspected. Once that inspection is finished, the state of the virtual machine can be made permanent, using the
-        xref:services-vm-methods-commit_snapshot[commit_snapshot] method, or discarded using the
-        xref:services-vm-methods-undo_snapshot[undo_snapshot] method.
-
+        `VmService.commit_snapshot` method, or discarded using the `VmService.undo_snapshot` method.
 
         This method supports the following parameters:
 
-        `disks`:: Specify the disks included in the snapshot's preview.
+        `disks` \n
+        Specify the disks included in the snapshot's preview.
         For each disk parameter, it is also required to specify its `image_id`.
         For example, to preview a snapshot with identifier `456` which includes a disk with identifier `111` and its
         `image_id` as `222`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/previewsnapshot
-        ----
+        ```
         Request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <disks>
             <disk id="111">
@@ -32880,9 +34689,10 @@ class VmService(MeasurableService):
           </disks>
           <snapshot id="456"/>
         </action>
-        ----
+        ```
 
-        `lease`:: Specify the lease storage domain ID to use in the preview of the snapshot.
+        `lease` \n
+        Specify the lease storage domain ID to use in the preview of the snapshot.
         If lease parameter is not passed, then the previewed snapshot lease storage domain will be used.
         If lease parameter is passed with empty storage domain parameter, then no lease will be used
         for the snapshot preview.
@@ -32890,13 +34700,17 @@ class VmService(MeasurableService):
         only one of the leases domain IDs that belongs to one of the virtual machine snapshots.
         This is an optional parameter, set by default to `null`
 
-        `async_`:: Indicates if the preview should be performed asynchronously.
+        `async_` \n
+        Indicates if the preview should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -32937,42 +34751,47 @@ class VmService(MeasurableService):
         """
         Sends a reboot request to a virtual machine.
         For example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/reboot
-        ----
+        ```
         The reboot action does not take any action specific parameters; therefore, the request body should contain an
         empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
         To reboot the VM even if a backup is running for it,
         the action should include the 'force' element.
         For example, to force reboot virtual machine `123`:
-        ----
+        ```
         POST /ovirt-engine/api/vms/123/reboot
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <action>
             <force>true</force>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `force`:: Indicates if the VM should be forcibly rebooted even
+        `force` \n
+        Indicates if the VM should be forcibly rebooted even
         if a backup is running for it.
 
-        `async_`:: Indicates if the reboot should be performed asynchronously.
+        `async_` \n
+        Indicates if the reboot should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33006,27 +34825,33 @@ class VmService(MeasurableService):
         """
         Removes the virtual machine, including the virtual disks attached to it.
         For example, to remove the virtual machine with identifier `123`:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/vms/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `detach_only`:: Indicates if the attached virtual disks should be detached first and preserved instead of being removed.
+        `detach_only` \n
+        Indicates if the attached virtual disks should be detached first and preserved instead of being removed.
 
-        `force`:: Indicates if the virtual machine should be forcibly removed.
+        `force` \n
+        Indicates if the virtual machine should be forcibly removed.
         Locked virtual machines and virtual machines with locked disk images
         cannot be removed without this flag set to true.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33065,13 +34890,17 @@ class VmService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33101,27 +34930,31 @@ class VmService(MeasurableService):
         """
         Sends a reset request to a virtual machine.
         For example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/reset
-        ----
+        ```
         The reset action does not take any action specific parameters; therefore, the request body should contain an
         empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the reset should be performed asynchronously.
+        `async_` \n
+        Indicates if the reset should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33150,16 +34983,16 @@ class VmService(MeasurableService):
         """
         Captures screenshot of the current state of the VM.
         For example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/screenshot
-        ----
+        ```
         The screenshot action does not take any action specific parameters; therefore, the request body should contain an
         empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         """
@@ -33187,45 +35020,51 @@ class VmService(MeasurableService):
         """
         This operation sends a shutdown request to a virtual machine.
         For example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/shutdown
-        ----
+        ```
         The shutdown action does not take any action specific parameters;
         therefore, the request body should contain an empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
         To shutdown the VM even if a backup is running for it,
         the action should include the 'force' element.
         For example, to force shutdown virtual machine `123`:
-        ----
+        ```
         POST /ovirt-engine/api/vms/123/shutdown
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <action>
             <force>true</force>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `force`:: Indicates if the VM should be forcibly shutdown even
+        `force` \n
+        Indicates if the VM should be forcibly shutdown even
         if a backup is running for it.
 
-        `async_`:: Indicates if the shutdown should be performed asynchronously.
+        `async_` \n
+        Indicates if the shutdown should be performed asynchronously.
 
-        `reason`:: The reason the virtual machine was stopped.
+        `reason` \n
+        The reason the virtual machine was stopped.
         Optionally set by user when shutting down the virtual machine.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33270,25 +35109,27 @@ class VmService(MeasurableService):
         If the virtual environment is complete and the virtual machine contains all necessary components to function,
         it can be started.
         This example starts the virtual machine:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/start
-        ----
+        ```
         With a request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `pause`:: If set to `true`, start the virtual machine in paused mode. The default is `false`.
+        `pause` \n
+        If set to `true`, start the virtual machine in paused mode. The default is `false`.
 
-        `vm`:: The definition of the virtual machine for this specific run.
+        `vm` \n
+        The definition of the virtual machine for this specific run.
         For example:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <vm>
             <os>
@@ -33300,37 +35141,47 @@ class VmService(MeasurableService):
             </os>
           </vm>
         </action>
-        ----
+        ```
         This will set the boot device to the CDROM only for this specific start. After the virtual machine is
         powered off, this definition will be reverted.
 
-        `use_cloud_init`:: If set to `true`, the initialization type is set to _cloud-init_. The default value is `false`.
-        See link:https://cloudinit.readthedocs.io/en/latest[cloud-init documentation] for details.
+        `use_cloud_init` \n
+        If set to `true`, the initialization type is set to _cloud-init_. The default value is `false`.
+        See link:https://cloudinit.readthedocs.io/en/latest for details.
 
-        `use_sysprep`:: If set to `true`, the initialization type is set to _Sysprep_. The default value is `false`.
-        See link:https://en.wikipedia.org/wiki/Sysprep[Sysprep] for details.
+        `use_sysprep` \n
+        If set to `true`, the initialization type is set to _Sysprep_. The default value is `false`.
+        See link:https://en.wikipedia.org/wiki/Sysprep for details.
 
-        `use_ignition`:: If set to `true`, the initialization type is set to _Ignition_. The default value is `false`.
-        See link:https://coreos.com/ignition/docs/latest/[Ignition documentation] for details.
+        `use_ignition` \n
+        If set to `true`, the initialization type is set to _Ignition_. The default value is `false`.
+        See link:https://coreos.com/ignition/docs/latest/ for details.
 
-        `use_initialization`:: If set to `true`, the initialization type is set by the VM's OS.
+        `use_initialization` \n
+        If set to `true`, the initialization type is set by the VM's OS.
         Windows will set to _Sysprep_, Linux to _cloud-init_ and RedHat CoreOS to _Ignition_.
         If any of the initialization-types are explicitly set (useCloudInit, useSysprep or useIgnition),
         they will be prioritized and this flag will be ignored.
         The default value is `false`.
 
-        `async_`:: Indicates if the start action should be performed asynchronously.
+        `async_` \n
+        Indicates if the start action should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `volatile`:: Indicates that this run configuration will be discarded even in the case of guest-initiated reboot.
+        `volatile` \n
+        Indicates that this run configuration will be discarded even in the case of guest-initiated reboot.
         The default value is `false`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33380,45 +35231,51 @@ class VmService(MeasurableService):
         """
         This operation forces a virtual machine to power-off.
         For example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/stop
-        ----
+        ```
         The stop action does not take any action specific parameters;
         therefore, the request body should contain an empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
         To stop the VM even if a backup is running for it,
         the action should include the 'force' element.
         For example, to force stop virtual machine `123`:
-        ----
+        ```
         POST /ovirt-engine/api/vms/123/stop
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <action>
             <force>true</force>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `force`:: Indicates if the VM should be forcibly stop even
+        `force` \n
+        Indicates if the VM should be forcibly stop even
         if a backup is running for it.
 
-        `async_`:: Indicates if the stop action should be performed asynchronously.
+        `async_` \n
+        Indicates if the stop action should be performed asynchronously.
 
-        `reason`:: The reason the virtual machine was stopped.
+        `reason` \n
+        The reason the virtual machine was stopped.
         Optionally set by user when shutting down the virtual machine.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33453,27 +35310,31 @@ class VmService(MeasurableService):
         This operation saves the virtual machine state to disk and stops it.
         Start a suspended virtual machine and restore the virtual machine state with the start action.
         For example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/suspend
-        ----
+        ```
         The suspend action does not take any action specific parameters;
         therefore, the request body should contain an empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the suspend action should be performed asynchronously.
+        `async_` \n
+        Indicates if the suspend action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33506,25 +35367,29 @@ class VmService(MeasurableService):
         running virtual machine. Normally, this is done automatically by the manager, but this must be executed manually
         with the API for virtual machines using OpenStack Volume (Cinder) disks.
         Example:
-        [source]
-        ----
+        
+        ```
         POST /api/vms/123/thawfilesystems
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the thaw file systems action should be performed asynchronously.
+        `async_` \n
+        Indicates if the thaw file systems action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33555,21 +35420,21 @@ class VmService(MeasurableService):
         """
         Generates a time-sensitive authentication token for accessing a virtual machine's display.
         For example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/ticket
-        ----
+        ```
         The client-provided action optionally includes a desired ticket value and/or an expiry time in seconds.
         The response specifies the actual ticket value and expiry used.
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <ticket>
             <value>abcd12345</value>
             <expiry>120</expiry>
           </ticket>
         </action>
-        ----
+        ```
         [IMPORTANT]
         ====
         If the virtual machine is configured to support only one graphics protocol
@@ -33578,25 +35443,28 @@ class VmService(MeasurableService):
         VNC and SPICE, then the authentication token will only be valid for
         the SPICE protocol.
         In order to obtain an authentication token for a specific protocol, for
-        example for VNC, use the `ticket` method of the
-        xref:services-vm_graphics_console[service], which manages the graphics consoles of the virtual machine, by sending
-        a request:
-        [source]
-        ----
+        example for VNC, use the `ticket` method of the `VmService.graphics_consoles_service`, 
+        which manages the graphics consoles of the virtual machine, by sending a request:
+        
+        ```
         POST /ovirt-engine/api/vms/123/graphicsconsoles/456/ticket
-        ----
+        ```
         ====
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the generation of the ticket should be performed asynchronously.
+        `async_` \n
+        Indicates if the generation of the ticket should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33634,21 +35502,28 @@ class VmService(MeasurableService):
 
         This method supports the following parameters:
 
-        `discard_snapshots`:: Use the `discard_snapshots` parameter when the virtual machine should be exported with all of its
+        `discard_snapshots` \n
+        Use the `discard_snapshots` parameter when the virtual machine should be exported with all of its
         snapshots collapsed.
 
-        `exclusive`:: Use the `exclusive` parameter when the virtual machine should be exported even if another copy of
+        `exclusive` \n
+        Use the `exclusive` parameter when the virtual machine should be exported even if another copy of
         it already exists in the export domain (override).
 
-        `storage_domain`:: The (export) storage domain to export the virtual machine to.
+        `storage_domain` \n
+        The (export) storage domain to export the virtual machine to.
 
-        `async_`:: Indicates if the export should be performed asynchronously.
+        `async_` \n
+        Indicates if the export should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33693,29 +35568,39 @@ class VmService(MeasurableService):
 
         This method supports the following parameters:
 
-        `host`:: The host to generate the OVA file on.
+        `host` \n
+        The host to generate the OVA file on.
 
-        `directory`:: An absolute path of a directory on the host to generate the OVA file in.
+        `directory` \n
+        An absolute path of a directory on the host to generate the OVA file in.
 
-        `filename`:: The name of the OVA file.
+        `filename` \n
+        The name of the OVA file.
         This is an optional parameter, if it is not specified then the name of OVA file is determined according
         to the name of the virtual machine. It will conform the following pattern: "<virtual machine name>.ova".
 
-        `discard_snapshots`:: Use the `discard_snapshots` parameter when the virtual machine should be exported with all of its
+        `discard_snapshots` \n
+        Use the `discard_snapshots` parameter when the virtual machine should be exported with all of its
         snapshots collapsed.
 
-        `exclusive`:: Use the `exclusive` parameter when the virtual machine should be exported even if another copy of
+        `exclusive` \n
+        Use the `exclusive` parameter when the virtual machine should be exported even if another copy of
         it already exists in the export domain (override).
 
-        `storage_domain`:: The (export) storage domain to export the virtual machine to.
+        `storage_domain` \n
+        The (export) storage domain to export the virtual machine to.
 
-        `async_`:: Indicates if the export should be performed asynchronously.
+        `async_` \n
+        Indicates if the export should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -33756,18 +35641,21 @@ class VmService(MeasurableService):
     ):
         """
         Restores the virtual machine to the state it had before previewing the snapshot.
-        See the xref:services-vm-methods-preview_snapshot[preview_snapshot] operation for details.
-
+        See the `VmService.preview_snapshot` operation for details.
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the undo snapshot action should be performed asynchronously.
+        `async_` \n
+        Indicates if the undo snapshot action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34046,16 +35934,21 @@ class VmApplicationService(Service):
 
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34113,18 +36006,24 @@ class VmApplicationsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of applications to return. If not specified all the applications are returned.
+        `max` \n
+        Sets the maximum number of applications to return. If not specified all the applications are returned.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34194,15 +36093,15 @@ class VmBackupService(Service):
         End backup, unlock resources, and perform cleanups.
         To finalize a virtual machine with an id '123' and a backup with an id '456'
         send a request as follows:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/backups/456/finalize
-        ----
+        ```
         With a request body as follows:
-        [source,xml]
-        ----
+        
+        ```xml
         <action />
-        ----
+        ```
 
 
         """
@@ -34231,14 +36130,18 @@ class VmBackupService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34297,14 +36200,18 @@ class VmBackupDiskService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34354,16 +36261,21 @@ class VmBackupDisksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of disks to return. If not specified, all the disks are returned.
+        `max` \n
+        Sets the maximum number of disks to return. If not specified, all the disks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34431,13 +36343,13 @@ class VmBackupsService(Service):
         Adds a new backup entity to a virtual machine.
         For example, to start a new incremental backup of a virtual machine
         since checkpoint id `previous-checkpoint-uuid`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/backups
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <backup>
           <from_checkpoint_id>previous-checkpoint-uuid</from_checkpoint_id>
           <disks>
@@ -34445,10 +36357,10 @@ class VmBackupsService(Service):
               ...
           </disks>
         </backup>
-        ----
+        ```
         The response body:
-        [source,xml]
-        ----
+        
+        ```xml
         <backup id="backup-uuid">
             <from_checkpoint_id>previous-checkpoint-uuid</from_checkpoint_id>
             <to_checkpoint_id>new-checkpoint-uuid</to_checkpoint_id>
@@ -34460,15 +36372,15 @@ class VmBackupsService(Service):
             <status>initializing</status>
             <creation_date>
         </backup>
-        ----
+        ```
         To provide the ID of the created backup, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/backups
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <backup id="backup-uuid">
           <from_checkpoint_id>previous-checkpoint-uuid</from_checkpoint_id>
           <disks>
@@ -34476,18 +36388,22 @@ class VmBackupsService(Service):
               ...
           </disks>
         </backup>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `backup`:: The information about the virtual machine backup entity.
+        `backup` \n
+        The information about the virtual machine backup entity.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34523,16 +36439,21 @@ class VmBackupsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of virtual machine backups to return. If not specified, all the virtual machine backups are returned.
+        `max` \n
+        Sets the maximum number of virtual machine backups to return. If not specified, all the virtual machine backups are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34601,35 +36522,40 @@ class VmCdromService(Service):
         The information consists of `cdrom` attribute containing reference to the CDROM device, the virtual machine,
         and optionally the inserted disk.
         If there is a disk inserted then the `file` attribute will contain a reference to the ISO image:
-        [source,xml]
-        ----
+        
+        ```xml
         <cdrom href="..." id="00000000-0000-0000-0000-000000000000">
           <file id="mycd.iso"/>
           <vm href="/ovirt-engine/api/vms/123" id="123"/>
         </cdrom>
-        ----
+        ```
         If there is no disk inserted then the `file` attribute won't be reported:
-        [source,xml]
-        ----
+        
+        ```xml
         <cdrom href="..." id="00000000-0000-0000-0000-000000000000">
           <vm href="/ovirt-engine/api/vms/123" id="123"/>
         </cdrom>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `current`:: Indicates if the operation should return the information for the currently running virtual machine. This
+        `current` \n
+        Indicates if the operation should return the information for the currently running virtual machine. This
         parameter is optional, and the default value is `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34661,54 +36587,58 @@ class VmCdromService(Service):
         Updates the information about this CDROM device.
         It allows to change or eject the disk by changing the value of the `file` attribute.
         For example, to insert or change the disk send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/vms/123/cdroms/00000000-0000-0000-0000-000000000000
-        ----
+        ```
         The body should contain the new value for the `file` attribute:
-        [source,xml]
-        ----
+        
+        ```xml
         <cdrom>
           <file id="mycd.iso"/>
         </cdrom>
-        ----
+        ```
         The value of the `id` attribute, `mycd.iso` in this example, should correspond to a file available in an
         attached ISO storage domain.
         To eject the disk use a `file` with an empty `id`:
-        [source,xml]
-        ----
+        
+        ```xml
         <cdrom>
           <file id=""/>
         </cdrom>
-        ----
+        ```
         By default the above operations change permanently the disk that will be visible to the virtual machine
         after the next boot, but they do not have any effect on the currently running virtual machine. If you want
         to change the disk that is visible to the current running virtual machine, add the `current=true` parameter.
         For example, to eject the current disk send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/vms/123/cdroms/00000000-0000-0000-0000-000000000000?current=true
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <cdrom>
           <file id=""/>
         </cdrom>
-        ----
+        ```
         IMPORTANT: The changes made with the `current=true` parameter are never persisted, so they won't have any
         effect after the virtual machine is rebooted.
 
 
         This method supports the following parameters:
 
-        `cdrom`:: The information about the CDROM device.
+        `cdrom` \n
+        The information about the CDROM device.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34742,9 +36672,7 @@ class VmCdromsService(Service):
     Manages the CDROM devices of a virtual machine.
     Currently virtual machines have exactly one CDROM device. No new devices can be added, and the existing one can't
     be removed, thus there are no `add` or `remove` methods. Changing and ejecting CDROM disks is done with the
-    xref:services-vm_cdrom-methods-update[update] method of the xref:services-vm_cdrom[service] that manages the
-    CDROM device.
-
+    `VmCdromService.update` method of the `VmCdRomService` that manages the CDROM device.
     """
 
     def __init__(self, connection, path):
@@ -34791,16 +36719,21 @@ class VmCdromsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of CDROMs to return. If not specified all the CDROMs are returned.
+        `max` \n
+        Sets the maximum number of CDROMs to return. If not specified all the CDROMs are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34868,14 +36801,18 @@ class VmCheckpointService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34905,13 +36842,17 @@ class VmCheckpointService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -34975,14 +36916,18 @@ class VmCheckpointDiskService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35032,16 +36977,21 @@ class VmCheckpointDisksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of disks to return. If not specified, all the disks are returned.
+        `max` \n
+        Sets the maximum number of disks to return. If not specified, all the disks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35107,25 +37057,30 @@ class VmCheckpointsService(Service):
         """
         The list of virtual machine checkpoints.
         To get a list of checkpoints for a virtual machine with an id '123', send a request as follows:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/vms/123/checkpoints
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of virtual machine checkpoints to return.
+        `max` \n
+        Sets the maximum number of virtual machine checkpoints to return.
         If not specified, all the virtual machine checkpoints are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35189,13 +37144,17 @@ class VmDiskService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the activation should be performed asynchronously.
+        `async_` \n
+        Indicates if the activation should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35225,13 +37184,17 @@ class VmDiskService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the deactivation should be performed asynchronously.
+        `async_` \n
+        Indicates if the deactivation should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35262,15 +37225,20 @@ class VmDiskService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the export should be performed asynchronously.
+        `async_` \n
+        Indicates if the export should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35302,14 +37270,18 @@ class VmDiskService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35336,15 +37308,20 @@ class VmDiskService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the move should be performed asynchronously.
+        `async_` \n
+        Indicates if the move should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35382,13 +37359,17 @@ class VmDiskService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35418,18 +37399,22 @@ class VmDiskService(MeasurableService):
         """
         Detach the disk from the virtual machine.
         NOTE: In version 3 of the API this used to also remove the disk completely from the system, but starting with
-        version 4 it doesn't. If you need to remove it completely use the xref:services-disk-methods-remove[remove method of the top level disk service].
-
+        version 4 it doesn't. If you need to remove it completely use the `DiskService.remove` method of the top level
+        disk service.
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35554,16 +37539,21 @@ class VmDisksService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of disks to return. If not specified all the disks are returned.
+        `max` \n
+        Sets the maximum number of disks to return. If not specified all the disks are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35633,26 +37623,31 @@ class VmGraphicsConsoleService(Service):
 
         This method supports the following parameters:
 
-        `current`:: Specifies if the data returned should correspond to the next execution of
+        `current` \n
+        Specifies if the data returned should correspond to the next execution of
         the virtual machine, or to the current execution.
         IMPORTANT: The `address` and `port` attributes will not be populated unless the value is
         `true`.
         For example, to get data for the current execution of the virtual machine, including the
         `address` and `port` attributes, send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovit-engine/api/vms/123/graphicsconsoles/456?current=true
-        ----
+        ```
         The default value is `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35682,13 +37677,17 @@ class VmGraphicsConsoleService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the generation of the ticket should be performed asynchronously.
+        `async_` \n
+        Indicates if the generation of the ticket should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35718,19 +37717,19 @@ class VmGraphicsConsoleService(Service):
         Generates the file which is compatible with `remote-viewer` client.
         Use the following request to generate remote viewer connection file of the graphics console.
         Note that this action generates the file only if virtual machine is running.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/graphicsconsoles/456/remoteviewerconnectionfile
-        ----
+        ```
         The `remoteviewerconnectionfile` action does not take any action specific parameters,
         so the request body should contain an empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
         The response contains the file, which can be used with `remote-viewer` client.
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <remote_viewer_connection_file>
             [virt-viewer]
@@ -35752,11 +37751,11 @@ class VmGraphicsConsoleService(Service):
             ca=...
           </remote_viewer_connection_file>
         </action>
-        ----
+        ```
         E.g., to fetch the content of remote viewer connection file and save it into temporary file, user can use
         oVirt Python SDK as follows:
-        [source,python]
-        ----
+
+        ```python
         # Find the virtual machine:
         vm = vms_service.list(search='name=myvm')[0]
         # Locate the service that manages the virtual machine, as that is where
@@ -35772,14 +37771,14 @@ class VmGraphicsConsoleService(Service):
         path = "/tmp/remote_viewer_connection_file.vv"
         with open(path, "w") as f:
             f.write(remote_viewer_connection_file)
-        ----
+        ```
         When you create the remote viewer connection file, then you can connect to virtual machine graphic console,
         as follows:
-        [source,bash]
-        ----
+
+        ```bash
         #!/bin/sh -ex
         remote-viewer --ovirt-ca-file=/etc/pki/ovirt-engine/ca.pem /tmp/remote_viewer_connection_file.vv
-        ----
+        ```
 
 
         """
@@ -35808,13 +37807,17 @@ class VmGraphicsConsoleService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35844,32 +37847,36 @@ class VmGraphicsConsoleService(Service):
     ):
         """
         Generates a time-sensitive authentication token for accessing this virtual machine's console.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/graphicsconsoles/456/ticket
-        ----
+        ```
         The client-provided action optionally includes a desired ticket value and/or an expiry time in seconds.
         In any case, the response specifies the actual ticket value and expiry used.
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <ticket>
             <value>abcd12345</value>
             <expiry>120</expiry>
           </ticket>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `ticket`:: The generated ticket that can be used to access this console.
+        `ticket` \n
+        The generated ticket that can be used to access this console.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -35951,28 +37958,34 @@ class VmGraphicsConsolesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of consoles to return. If not specified all the consoles are returned.
+        `max` \n
+        Sets the maximum number of consoles to return. If not specified all the consoles are returned.
 
-        `current`:: Specifies if the data returned should correspond to the next execution of
+        `current` \n
+        Specifies if the data returned should correspond to the next execution of
         the virtual machine, or to the current execution.
         IMPORTANT: The `address` and `port` attributes will not be populated unless the value is
         `true`.
         For example, to get data for the current execution of the virtual machine, including the
         `address` and `port` attributes, send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/vms/123/graphicsconsoles?current=true
-        ----
+        ```
         The default value is `false`.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36040,12 +38053,12 @@ class VmHostDeviceService(Service):
         """
         Retrieve information about particular host device attached to given virtual machine.
         Example:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/vms/123/hostdevices/456
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <host_device href="/ovirt-engine/api/hosts/543/devices/456" id="456">
           <name>pci_0000_04_00_0</name>
           <capability>pci</capability>
@@ -36063,19 +38076,23 @@ class VmHostDeviceService(Service):
           </parent_device>
           <vm href="/ovirt-engine/api/vms/123" id="123"/>
         </host_device>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36104,21 +38121,25 @@ class VmHostDeviceService(Service):
         in setting its `placeholder` flag to `true`). Note that all IOMMU placeholder devices will be removed
         automatically as soon as there will be no more non-placeholder devices (all devices from given IOMMU
         group are detached).
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/vms/123/hostdevices/456
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36171,33 +38192,37 @@ class VmHostDevicesService(Service):
         """
         Attach target device to given virtual machine.
         Example:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/hostdevices
-        ----
-        With request body of type xref:types-host_device[HostDevice], for example
-        [source,xml]
-        ----
+        ```
+        With request body of type `ovirtsdk4.types.HostDevice` for example
+        
+        ```xml
         <host_device id="123" />
-        ----
+        ```
         NOTE: A necessary precondition for a successful host device attachment is that the virtual machine must be pinned
         to *exactly* one host. The device ID is then taken relative to this host.
         NOTE: Attachment of a PCI device that is part of a bigger IOMMU group will result in attachment of the remaining
         devices from that IOMMU group as "placeholders". These devices are then identified using the `placeholder`
-        attribute of the xref:types-host_device[HostDevice] type set to `true`.
+        attribute of the `ovirtsdk4.types.HostDevice` type set to `true`.
         In case you want attach a device that already serves as an IOMMU placeholder, simply issue an explicit Add operation
         for it, and its `placeholder` flag will be cleared, and the device will be accessible to the virtual machine.
 
 
         This method supports the following parameters:
 
-        `device`:: The host device to be attached to given virtual machine.
+        `device` \n
+        The host device to be attached to given virtual machine.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36226,16 +38251,21 @@ class VmHostDevicesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of devices to return. If not specified all the devices are returned.
+        `max` \n
+        Sets the maximum number of devices to return. If not specified all the devices are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36300,14 +38330,18 @@ class VmMediatedDeviceService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36336,13 +38370,17 @@ class VmMediatedDeviceService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36375,8 +38413,8 @@ class VmMediatedDeviceService(Service):
         Updates the information about the mediated device.
         You can update the information using `specParams` element.
         For example, to update a mediated device, send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/vms/123/mediateddevices/00000000-0000-0000-0000-000000000000
         <vm_mediated_device>
           <spec_params>
@@ -36386,10 +38424,10 @@ class VmMediatedDeviceService(Service):
             </property>
           </spec_params>
         </vm_mediated_device>
-        ----
+        ```
         with response body:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm_mediated_device href="/ovirt-engine/api/vms/123/mediateddevices/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000">
           <vm href="/ovirt-engine/api/vms/123" id="123"/>
           <spec_params>
@@ -36399,21 +38437,25 @@ class VmMediatedDeviceService(Service):
             </property>
           </spec_params>
         </vm_mediated_device>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `device`:: The information about the mediated device.
+        `device` \n
+        The information about the mediated device.
         The request data must contain `specParams` properties.
         The response data contains complete information about the
         updated mediated device.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36496,17 +38538,22 @@ class VmMediatedDevicesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of mediated devices to return.
+        `max` \n
+        Sets the maximum number of mediated devices to return.
         If not specified all the mediated devices are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36571,13 +38618,17 @@ class VmNicService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the activation should be performed asynchronously.
+        `async_` \n
+        Indicates if the activation should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36607,13 +38658,17 @@ class VmNicService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the deactivation should be performed asynchronously.
+        `async_` \n
+        Indicates if the deactivation should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36643,14 +38698,18 @@ class VmNicService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36676,10 +38735,10 @@ class VmNicService(MeasurableService):
         """
         Removes the NIC.
         For example, to remove the NIC with id `456` from the virtual machine with id `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/vms/123/nics/456
-        ----
+        ```
         [IMPORTANT]
         ====
         The hotplugging feature only supports virtual machine operating systems with hotplugging operations.
@@ -36693,13 +38752,17 @@ class VmNicService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36732,19 +38795,19 @@ class VmNicService(MeasurableService):
         Updates the NIC.
         For example, to update the NIC having with `456` belonging to virtual the machine with id `123` send a request
         like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/vms/123/nics/456
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <nic>
           <name>mynic</name>
           <interface>e1000</interface>
           <vnic_profile id='789'/>
         </nic>
-        ----
+        ```
         [IMPORTANT]
         ====
         The hotplugging feature only supports virtual machine operating systems with hotplugging operations.
@@ -36779,8 +38842,7 @@ class VmNicService(MeasurableService):
     def network_filter_parameters_service(self):
         """
         Reference to the service that manages the network filter parameters of the NIC.
-        A single top-level network filter may assigned to the NIC by the NIC's xref:types-vnic_profile[vNIC Profile].
-
+        A single top-level network filter may assigned to the NIC by the NIC's `ovirtsdk4.types.Nic.vnic_profile`.
         """
         return NicNetworkFilterParametersService(self._connection, '%s/networkfilterparameters' % self._path)
 
@@ -36838,21 +38900,21 @@ class VmNicsService(Service):
         Adds a NIC to the virtual machine.
         The following example adds to the virtual machine `123` a network interface named `mynic` using `virtio` and the
         NIC profile `456`.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/nics
-        ----
-        [source,xml]
-        ----
+        ```
+        
+        ```xml
         <nic>
           <name>mynic</name>
           <interface>virtio</interface>
           <vnic_profile id="456"/>
         </nic>
-        ----
+        ```
         The following example sends that request using `curl`:
-        [source,bash]
-        ----
+
+        ```bash
         curl \
         --request POST \
         --header "Version: 4" \
@@ -36868,7 +38930,7 @@ class VmNicsService(Service):
         </nic>
         ' \
         https://myengine.example.com/ovirt-engine/api/vms/123/nics
-        ----
+        ```
         [IMPORTANT]
         ====
         The hotplugging feature only supports virtual machine operating systems with hotplugging operations.
@@ -36908,16 +38970,21 @@ class VmNicsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of NICs to return. If not specified all the NICs are returned.
+        `max` \n
+        Sets the maximum number of NICs to return. If not specified all the NICs are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -36977,14 +39044,18 @@ class VmNumaNodeService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37010,23 +39081,27 @@ class VmNumaNodeService(Service):
         """
         Removes a virtual NUMA node.
         An example of removing a virtual NUMA node:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/vms/123/numanodes/456
-        ----
+        ```
         NOTE: It's required to remove the numa nodes from the highest index
         first.
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37058,13 +39133,13 @@ class VmNumaNodeService(Service):
         """
         Updates a virtual NUMA node.
         An example of pinning a virtual NUMA node to a physical NUMA node on the host:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/vms/123/numanodes/456
-        ----
+        ```
         The request body should contain the following:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm_numa_node>
           <numa_node_pins>
             <numa_node_pin>
@@ -37072,7 +39147,7 @@ class VmNumaNodeService(Service):
             </numa_node_pin>
           </numa_node_pins>
         </vm_numa_node>
-        ----
+        ```
 
 
         """
@@ -37126,15 +39201,15 @@ class VmNumaNodesService(Service):
         """
         Creates a new virtual NUMA node for the virtual machine.
         An example of creating a NUMA node:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/c7ecd2dc/numanodes
         Accept: application/xml
         Content-type: application/xml
-        ----
+        ```
         The request body can contain the following:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm_numa_node>
           <cpu>
             <cores>
@@ -37147,7 +39222,7 @@ class VmNumaNodesService(Service):
           <memory>1024</memory>
           <numa_tune_mode>strict</numa_tune_mode>
         </vm_numa_node>
-        ----
+        ```
 
 
         """
@@ -37178,16 +39253,21 @@ class VmNumaNodesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of nodes to return. If not specified all the nodes are returned.
+        `max` \n
+        Sets the maximum number of nodes to return. If not specified all the nodes are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37249,27 +39329,31 @@ class VmPoolService(Service):
     ):
         """
         This operation allocates a virtual machine in the virtual machine pool.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vmpools/123/allocatevm
-        ----
+        ```
         The allocate virtual machine action does not take any action specific parameters, so the request body should
         contain an empty `action`:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the allocation should be performed asynchronously.
+        `async_` \n
+        Indicates if the allocation should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37299,13 +39383,13 @@ class VmPoolService(Service):
     ):
         """
         Get the virtual machine pool.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/vmpools/123
-        ----
+        ```
         You will get a XML response like that one:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm_pool id="123">
           <actions>...</actions>
           <name>MyVmPool</name>
@@ -37322,21 +39406,26 @@ class VmPoolService(Service):
           <vm id="123">...</vm>
           ...
         </vm_pool>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37365,21 +39454,25 @@ class VmPoolService(Service):
     ):
         """
         Removes a virtual machine pool.
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/vmpools/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37411,15 +39504,15 @@ class VmPoolService(Service):
     ):
         """
         Update the virtual machine pool.
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/vmpools/123
-        ----
+        ```
         The `name`, `description`, `size`, `prestarted_vms` and `max_user_vms`
         attributes can be updated after the virtual machine pool has been
         created.
-        [source,xml]
-        ----
+        
+        ```xml
         <vmpool>
           <name>VM_Pool_B</name>
           <description>Virtual Machine Pool B</description>
@@ -37427,18 +39520,22 @@ class VmPoolService(Service):
           <prestarted_vms>1</size>
           <max_user_vms>2</size>
         </vmpool>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `pool`:: The virtual machine pool that is being updated.
+        `pool` \n
+        The virtual machine pool that is being updated.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37509,30 +39606,34 @@ class VmPoolsService(Service):
         Creates a new virtual machine pool.
         A new pool requires the `name`, `cluster` and `template` attributes. Identify the cluster and template with the
         `id` or `name` nested attributes:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vmpools
-        ----
+        ```
         With the following body:
-        [source,xml]
-        ----
+        
+        ```xml
         <vmpool>
           <name>mypool</name>
           <cluster id="123"/>
           <template id="456"/>
         </vmpool>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `pool`:: Pool to add.
+        `pool` \n
+        Pool to add.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37563,44 +39664,52 @@ class VmPoolsService(Service):
     ):
         """
         Get a list of available virtual machines pools.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/vmpools
-        ----
+        ```
         You will receive the following response:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm_pools>
           <vm_pool id="123">
             ...
           </vm_pool>
           ...
         </vm_pools>
-        ----
+        ```
         The order of the returned list of pools is guaranteed only if the `sortby` clause is included in the
         `search` parameter.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of pools to return. If this value is not specified, all of the pools are returned.
+        `max` \n
+        Sets the maximum number of pools to return. If this value is not specified, all of the pools are returned.
 
-        `search`:: A query string used to restrict the returned pools.
+        `search` \n
+        A query string used to restrict the returned pools.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37673,14 +39782,18 @@ class VmReportedDeviceService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37731,16 +39844,21 @@ class VmReportedDevicesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of devices to return. If not specified all the devices are returned.
+        `max` \n
+        Sets the maximum number of devices to return. If not specified all the devices are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37800,14 +39918,18 @@ class VmSessionService(Service):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37856,13 +39978,13 @@ class VmSessionsService(Service):
         """
         Lists all user sessions for this virtual machine.
         For example, to retrieve the session information for virtual machine `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/vms/123/sessions
-        ----
+        ```
         The response body will contain something like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <sessions>
           <session href="/ovirt-engine/api/vms/123/sessions/456" id="456">
             <console_user>true</console_user>
@@ -37874,22 +39996,27 @@ class VmSessionsService(Service):
           </session>
           ...
         </sessions>
-        ----
+        ```
         The order of the returned list of sessions isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of sessions to return. If not specified all the sessions are returned.
+        `max` \n
+        Sets the maximum number of sessions to return. If not specified all the sessions are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37956,14 +40083,18 @@ class VmWatchdogService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -37989,21 +40120,25 @@ class VmWatchdogService(Service):
         """
         Removes the watchdog from the virtual machine.
         For example, to remove a watchdog from a virtual machine, send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/vms/123/watchdogs/00000000-0000-0000-0000-000000000000
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -38036,36 +40171,40 @@ class VmWatchdogService(Service):
         Updates the information about the watchdog.
         You can update the information using `action` and `model` elements.
         For example, to update a watchdog, send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/vms/123/watchdogs
         <watchdog>
           <action>reset</action>
         </watchdog>
-        ----
+        ```
         with response body:
-        [source,xml]
-        ----
+        
+        ```xml
         <watchdog href="/ovirt-engine/api/vms/123/watchdogs/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000">
           <vm href="/ovirt-engine/api/vms/123" id="123"/>
           <action>reset</action>
           <model>i6300esb</model>
         </watchdog>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `watchdog`:: The information about the watchdog.
+        `watchdog` \n
+        The information about the watchdog.
         The request data must contain at least one of `model` and `action`
         elements. The response data contains complete information about the
         updated watchdog.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -38119,37 +40258,41 @@ class VmWatchdogsService(Service):
         """
         Adds new watchdog to the virtual machine.
         For example, to add a watchdog to a virtual machine, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/vms/123/watchdogs
         <watchdog>
           <action>poweroff</action>
           <model>i6300esb</model>
         </watchdog>
-        ----
+        ```
         with response body:
-        [source,xml]
-        ----
+        
+        ```xml
         <watchdog href="/ovirt-engine/api/vms/123/watchdogs/00000000-0000-0000-0000-000000000000" id="00000000-0000-0000-0000-000000000000">
           <vm href="/ovirt-engine/api/vms/123" id="123"/>
           <action>poweroff</action>
           <model>i6300esb</model>
         </watchdog>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `watchdog`:: The information about the watchdog.
+        `watchdog` \n
+        The information about the watchdog.
         The request data must contain `model` element (such as `i6300esb`) and `action` element
         (one of `none`, `reset`, `poweroff`, `dump`, `pause`). The response data additionally
         contains references to the added watchdog and to the virtual machine.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -38178,16 +40321,21 @@ class VmWatchdogsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of watchdogs to return. If not specified all the watchdogs are returned.
+        `max` \n
+        Sets the maximum number of watchdogs to return. If not specified all the watchdogs are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -38257,8 +40405,8 @@ class VmsService(Service):
         The virtual machine can be created in different ways:
         - From a template. In this case the identifier or name of the template must be provided. For example, using a
           plain shell script and XML:
-        [source,bash]
-        ----
+
+        ```bash
         #!/bin/sh -ex
         url="https://engine.example.com/ovirt-engine/api"
         user="admin@internal"
@@ -38283,11 +40431,11 @@ class VmsService(Service):
         </vm>
         ' \
         "${url}/vms"
-        ----
+        ```
         - From a snapshot. In this case the identifier of the snapshot has to be provided. For example, using a plain
           shel script and XML:
-        [source,bash]
-        ----
+
+        ```bash
         #!/bin/sh -ex
         url="https://engine.example.com/ovirt-engine/api"
         user="admin@internal"
@@ -38311,12 +40459,12 @@ class VmsService(Service):
         </vm>
         ' \
         "${url}/vms"
-        ----
+        ```
         When creating a virtual machine from a template or from a snapshot it is usually useful to explicitly indicate
         in what storage domain to create the disks for the virtual machine. If the virtual machine is created from
         a template then this is achieved passing a set of `disk_attachment` elements that indicate the mapping:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm>
           ...
           <disk_attachments>
@@ -38329,11 +40477,11 @@ class VmsService(Service):
             <disk_attachment>
           </disk_attachments>
         </vm>
-        ----
+        ```
         When the virtual machine is created from a snapshot this set of disks is slightly different, it uses the
         `image_id` attribute instead of `id`.
-        [source,xml]
-        ----
+        
+        ```xml
         <vm>
           ...
           <disk_attachments>
@@ -38347,12 +40495,12 @@ class VmsService(Service):
             <disk_attachment>
           </disk_attachments>
         </vm>
-        ----
+        ```
         It is possible to specify additional virtual machine parameters in the XML description, e.g. a virtual machine
         of `desktop` type, with 2 GiB of RAM and additional description can be added sending a request body like the
         following:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm>
           <name>myvm</name>
           <description>My Desktop Virtual Machine</description>
@@ -38360,22 +40508,22 @@ class VmsService(Service):
           <memory>2147483648</memory>
           ...
         </vm>
-        ----
+        ```
         A bootable CDROM device can be set like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm>
           ...
           <os>
             <boot dev="cdrom"/>
           </os>
         </vm>
-        ----
-        In order to boot from CDROM, you first need to insert a disk, as described in the
-        xref:services-vm_cdrom[CDROM service]. Then booting from that CDROM can be specified using the `os.boot.devices`
+        ```
+        In order to boot from CDROM, you first need to insert a disk, as described in the `VmCdromService`. 
+        Then booting from that CDROM can be specified using the `os.boot.devices`.
         attribute:
-        [source,xml]
-        ----
+        
+        ```xml
         <vm>
           ...
           <os>
@@ -38386,7 +40534,7 @@ class VmsService(Service):
             </boot>
           </os>
         </vm>
-        ----
+        ```
         In all cases the name or identifier of the cluster where the virtual machine will be created is mandatory.
 
 
@@ -38587,47 +40735,57 @@ class VmsService(Service):
 
         This method supports the following parameters:
 
-        `search`:: A query string used to restrict the returned virtual machines.
+        `search` \n
+        A query string used to restrict the returned virtual machines.
 
-        `max`:: The maximum number of results to return.
+        `max` \n
+        The maximum number of results to return.
 
-        `case_sensitive`:: Indicates if the search performed using the `search` parameter should be performed taking case into
+        `case_sensitive` \n
+        Indicates if the search performed using the `search` parameter should be performed taking case into
         account. The default value is `true`, which means that case is taken into account. If you want to search
         ignoring case set it to `false`.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `all_content`:: Indicates if all the attributes of the virtual machines should be included in the response.
+        `all_content` \n
+        Indicates if all the attributes of the virtual machines should be included in the response.
         By default the following attributes are excluded:
         - `console`
-        - `initialization.configuration.data` - The OVF document describing the virtual machine.
+        - `ovirtsdk4.types.Initialization.configuration` - The OVF document describing the virtual machine.
         - `rng_source`
         - `soundcard`
         - `virtio_scsi`
         For example, to retrieve the complete representation of the virtual machines send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/vms?all_content=true
-        ....
+        ```
         NOTE: The reason for not including these attributes is performance: they are seldom used and they require
         additional queries to the database. So try to use the this parameter only when it is really needed.
 
-        `ovf_as_ova`:: Indicates if the results should expose the OVF as it appears in OVA files of that VM. The OVF document
+        `ovf_as_ova` \n
+        Indicates if the results should expose the OVF as it appears in OVA files of that VM. The OVF document
         describing the virtual machine. This parameter will work only when all_content=True is set.
-        The OVF will be presented in `initialization.configuration.data`.
+        The OVF will be presented in `ovirtsdk4.types.Initialization.configuration`.
         For example:
-        [source]
-        ----
+        
+        ```
         GET /vms?all_content=true&ovf_as_ova=true
-        ----
+        ```
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -38712,14 +40870,18 @@ class VnicProfileService(Service):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -38748,13 +40910,17 @@ class VnicProfileService(Service):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -38789,13 +40955,17 @@ class VnicProfileService(Service):
 
         This method supports the following parameters:
 
-        `profile`:: The vNIC profile that is being updated.
+        `profile` \n
+        The vNIC profile that is being updated.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -38858,13 +41028,13 @@ class VnicProfilesService(Service):
         """
         Add a vNIC profile.
         For example to add vNIC profile `123` to network `456` send a request to:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/networks/456/vnicprofiles
-        ----
+        ```
         With the following body:
-        [source,xml]
-        ----
+        
+        ```xml
         <vnic_profile id="123">
           <name>new_vNIC_name</name>
           <pass_through>
@@ -38872,15 +41042,15 @@ class VnicProfilesService(Service):
           </pass_through>
           <port_mirroring>false</port_mirroring>
         </vnic_profile>
-        ----
+        ```
         Please note that there is a default network filter to each VNIC profile.
         For more details of how the default network filter is calculated please refer to
-        the documentation in xref:services-network_filters[NetworkFilters].
+        the documentation in `NetworkFiltersService`.
         NOTE: The automatically created vNIC profile for the external network will be without network filter.
         The output of creating a new VNIC profile depends in the  body  arguments that were given.
         In case no network filter was given, the default network filter will be configured. For example:
-        [source,xml]
-        ----
+        
+        ```xml
         <vnic_profile href="/ovirt-engine/api/vnicprofiles/123" id="123">
           <name>new_vNIC_name</name>
           <link href="/ovirt-engine/api/vnicprofiles/123/permissions" rel="permissions"/>
@@ -38891,36 +41061,40 @@ class VnicProfilesService(Service):
           <network href="/ovirt-engine/api/networks/456" id="456"/>
           <network_filter href="/ovirt-engine/api/networkfilters/789" id="789"/>
         </vnic_profile>
-        ----
+        ```
         In case an empty network filter was given, no network filter will be configured for the specific VNIC profile
         regardless of the VNIC profile's default network filter. For example:
-        [source,xml]
-        ----
+        
+        ```xml
         <vnic_profile>
           <name>no_network_filter</name>
           <network_filter/>
         </vnic_profile>
-        ----
+        ```
         In case that a specific valid network filter id was given, the VNIC profile will be configured with the given
         network filter regardless of the VNIC profiles's default network filter. For example:
-        [source,xml]
-        ----
+        
+        ```xml
         <vnic_profile>
           <name>user_choice_network_filter</name>
           <network_filter id= "0000001b-001b-001b-001b-0000000001d5"/>
         </vnic_profile>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `profile`:: The vNIC profile that is being added.
+        `profile` \n
+        The vNIC profile that is being added.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -38949,16 +41123,21 @@ class VnicProfilesService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of profiles to return. If not specified all the profiles are returned.
+        `max` \n
+        Sets the maximum number of profiles to return. If not specified all the profiles are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39019,16 +41198,21 @@ class WeightService(Service):
         """
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39058,13 +41242,17 @@ class WeightService(Service):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39145,18 +41333,24 @@ class WeightsService(Service):
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of weights to return. If not specified all the weights are returned.
+        `max` \n
+        Sets the maximum number of weights to return. If not specified all the weights are returned.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39207,8 +41401,8 @@ class AttachedStorageDomainDiskService(MeasurableService):
     Manages a single disk available in a storage domain attached to a data center.
     IMPORTANT: Since version 4.2 of the engine this service is intended only to list disks available in the storage
     domain, and to register unregistered disks. All the other operations, like copying a disk, moving a disk, etc, have
-    been deprecated and will be removed in the future. To perform those operations use the xref:services-disks[service that manages all the disks of the system]
-    or the xref:services-disk[service that manages a specific disk].
+    been deprecated and will be removed in the future. To perform those operations use the `DisksService` service that 
+    manages all the disks of the system or the `DiskService` service that manages a specific disk.
 
     """
 
@@ -39229,21 +41423,26 @@ class AttachedStorageDomainDiskService(MeasurableService):
         """
         Copies a disk to the specified storage domain.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To copy a disk use the xref:services-disk-methods-copy[copy]
+        compatibility. It will be removed in the future. To copy a disk use the `DiskService.copy` 
         operation of the service that manages that disk.
 
 
         This method supports the following parameters:
 
-        `disk`:: Description of the resulting disk.
+        `disk` \n
+        Description of the resulting disk.
 
-        `storage_domain`:: The storage domain where the new disk will be created.
+        `storage_domain` \n
+        The storage domain where the new disk will be created.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39271,19 +41470,23 @@ class AttachedStorageDomainDiskService(MeasurableService):
         """
         Exports a disk to an export storage domain.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To export a disk use the xref:services-disk-methods-export[export]
+        compatibility. It will be removed in the future. To export a disk use the `DiskService.export`
         operation of the service that manages that disk.
 
 
         This method supports the following parameters:
 
-        `storage_domain`:: The export storage domain where the disk should be exported to.
+        `storage_domain` \n
+        The export storage domain where the disk should be exported to.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39312,14 +41515,18 @@ class AttachedStorageDomainDiskService(MeasurableService):
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39347,23 +41554,29 @@ class AttachedStorageDomainDiskService(MeasurableService):
         """
         Moves a disk to another storage domain.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To move a disk use the xref:services-disk-methods-move[move]
+        compatibility. It will be removed in the future. To move a disk use the `DiskService.move` 
         operation of the service that manages that disk.
 
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain where the disk will be moved to.
+        `storage_domain` \n
+        The storage domain where the disk will be moved to.
 
-        `async_`:: Indicates if the move should be performed asynchronously.
+        `async_` \n
+        Indicates if the move should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39419,7 +41632,7 @@ class AttachedStorageDomainDiskService(MeasurableService):
         """
         Removes a disk.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To remove a disk use the xref:services-disk-methods-remove[remove]
+        compatibility. It will be removed in the future. To remove a disk use the `DiskService.remove`
         operation of the service that manages that disk.
 
 
@@ -39444,7 +41657,7 @@ class AttachedStorageDomainDiskService(MeasurableService):
         """
         Sparsify the disk.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To remove a disk use the xref:services-disk-methods-remove[remove]
+        compatibility. It will be removed in the future. To remove a disk use the `DiskService.remove`
         operation of the service that manages that disk.
 
 
@@ -39471,19 +41684,23 @@ class AttachedStorageDomainDiskService(MeasurableService):
         """
         Updates the disk.
         IMPORTANT: Since version 4.2 of the engine this operation is deprecated, and preserved only for backwards
-        compatibility. It will be removed in the future. To update a disk use the
-        xref:services-disk-methods-update[update] operation of the service that manages that disk.
+        compatibility. It will be removed in the future. To update a disk use the `DiskService.update`
+        operation of the service that manages that disk.
 
 
         This method supports the following parameters:
 
-        `disk`:: The update to apply to the disk.
+        `disk` \n
+        The update to apply to the disk.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39553,20 +41770,20 @@ class DiskService(MeasurableService):
         Converts disk format and/or preallocation mode.
         For example, to convert the disk format from preallocated-cow to a sparse-raw image,
         send a request like the following:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/disks/123/convert
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
          <action>
            <disk>
              <sparse>true</sparse>
              <format>raw</format>
            </disk>
          </action>
-        ----
+        ```
         Note: In order to sparsify a disk, two conversions might be needed if the disk is on a Block Storage Domain.
         For example: If a disk is RAW, converting it to QCOW will result in a larger disk. In order to reduce the size,
         it is possible to convert the disk again to QCOW and keep the same allocation policy.
@@ -39574,16 +41791,21 @@ class DiskService(MeasurableService):
 
         This method supports the following parameters:
 
-        `disk`:: The description of the disk.
+        `disk` \n
+        The description of the disk.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39616,71 +41838,79 @@ class DiskService(MeasurableService):
         """
         This operation copies a disk to the specified storage domain.
         For example, a disk can be copied using the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/disks/123/copy
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain id="456"/>
           <disk>
             <name>mydisk</name>
           </disk>
         </action>
-        ----
+        ```
         If the disk profile or the quota currently used by the disk are not defined for the new storage domain, they
         can be explicitly specified. If they are not specified, the first available disk profile and the default quota are used.
         For example, to specify disk profile `987` and quota `753`, send a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain id="456"/>
           <disk_profile id="987"/>
           <quota id="753"/>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain where the new disk is created. This can be specified using the `id` or `name`
+        `storage_domain` \n
+        The storage domain where the new disk is created. This can be specified using the `id` or `name`
         attributes. For example, to copy a disk to the storage domain called `mydata`, send a request like this:
-        ....
+        ```
         POST /ovirt-engine/api/storagedomains/123/disks/789
-        ....
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain>
             <name>mydata</name>
           </storage_domain>
         </action>
-        ----
+        ```
 
-        `disk_profile`:: Disk profile for the disk in the new storage domain.
+        `disk_profile` \n
+        Disk profile for the disk in the new storage domain.
         Disk profiles are defined for storage domains,
         so the old disk profile will not exist in the new storage domain.
         If this parameter is not used, the first disk profile from the new storage domain
         to which the user has permissions will be assigned to the disk.
 
-        `quota`:: Quota for the disk in the new storage domain.
+        `quota` \n
+        Quota for the disk in the new storage domain.
         This optional parameter can be used to specify new quota for the disk,
         because the current quota may not be defined for the new storage domain.
         If this parameter is not used and the old quota is not defined for the new storage domain,
         the default (unlimited) quota will be assigned to the disk.
 
-        `async_`:: Indicates if the copy should be performed asynchronously.
+        `async_` \n
+        Indicates if the copy should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39725,17 +41955,23 @@ class DiskService(MeasurableService):
 
         This method supports the following parameters:
 
-        `storage_domain`:: The export storage domain where the disk will be exported to.
+        `storage_domain` \n
+        The export storage domain where the disk will be exported to.
 
-        `async_`:: Indicates if the export should be performed asynchronously.
+        `async_` \n
+        Indicates if the export should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39773,22 +42009,27 @@ class DiskService(MeasurableService):
 
         This method supports the following parameters:
 
-        `all_content`:: Indicates if all of the attributes of the disk should be included in the response.
+        `all_content` \n
+        Indicates if all of the attributes of the disk should be included in the response.
         By default the following disk attributes are excluded:
         - `vms`
         For example, to retrieve the complete representation of disk '123':
-        ....
+        ```
         GET /ovirt-engine/api/disks/123?all_content=true
-        ....
+        ```
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39823,17 +42064,17 @@ class DiskService(MeasurableService):
         Moves a disk to another storage domain.
         For example, to move the disk with identifier `123` to a storage domain with identifier `456` send the following
         request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/disks/123/move
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain id="456"/>
         </action>
-        ----
+        ```
         If the disk profile or the quota used currently by
         the disk aren't defined for the new storage domain,
         then they can be explicitly specified. If they aren't
@@ -39841,41 +42082,49 @@ class DiskService(MeasurableService):
         quota are used.
         For example, to explicitly use disk profile `987` and
         quota `753` send a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <storage_domain id="456"/>
           <disk_profile id="987"/>
           <quota id="753"/>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `storage_domain`:: The storage domain where the disk will be moved to.
+        `storage_domain` \n
+        The storage domain where the disk will be moved to.
 
-        `disk_profile`:: Disk profile for the disk in the new storage domain.
+        `disk_profile` \n
+        Disk profile for the disk in the new storage domain.
         Disk profiles are defined for storage domains,
         so the old disk profile will not exist in the new storage domain.
         If this parameter is not used, the first disk profile from the new storage domain
         to which the user has permissions will be assigned to the disk.
 
-        `quota`:: Quota for the disk in the new storage domain.
+        `quota` \n
+        Quota for the disk in the new storage domain.
         This optional parameter can be used to specify new quota for the disk,
         because the current quota may not be defined for the new storage domain.
         If this parameter is not used and the old quota is not defined for the new storage domain,
         the default (unlimited) quota will be assigned to the disk.
 
-        `async_`:: Indicates if the move should be performed asynchronously.
+        `async_` \n
+        Indicates if the move should be performed asynchronously.
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39919,13 +42168,17 @@ class DiskService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -39956,31 +42209,35 @@ class DiskService(MeasurableService):
         Refreshes a direct LUN disk with up-to-date information from the storage.
         Refreshing a direct LUN disk is useful when:
         - The LUN was added using the API without the host parameter, and therefore does not contain
-          any information from the storage (see xref:services-disks-methods-add[DisksService::add]).
+          any information from the storage (see `DisksService.add`).
         - New information about the LUN is available on the storage and you want to update the LUN with it.
         To refresh direct LUN disk `123` using host `456`, send the following request:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/disks/123/refreshlun
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <host id='456'/>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `host`:: The host that will be used to refresh the direct LUN disk.
+        `host` \n
+        The host that will be used to refresh the direct LUN disk.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40009,13 +42266,17 @@ class DiskService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40079,32 +42340,36 @@ class DiskService(MeasurableService):
         * For Managed Block disks: `provisioned_size`, `alias` and `description`.
         * For VM attached disks, the `qcow_version` can also be updated.
         For example, a disk's update can be done by using the following request:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/disks/123
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <disk>
           <qcow_version>qcow2_v3</qcow_version>
           <alias>new-alias</alias>
           <description>new-desc</description>
         </disk>
-        ----
+        ```
         Since the backend operation is asynchronous, the disk element that is returned
         to the user might not be synced with the changed properties.
 
 
         This method supports the following parameters:
 
-        `disk`:: The update to apply to the disk.
+        `disk` \n
+        The update to apply to the disk.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40121,13 +42386,14 @@ class DiskService(MeasurableService):
         """
         Reference to the service that manages the DiskSnapshots.
         For example, to list all disk snapshots under the disks resource '123':
-        ....
+        ```
         GET /ovirt-engine/api/disks/123/disksnapshots
-        ....
+        ```
+
         For example, to retrieve a specific disk snapshot '789' under the disk resource '123':
-        ....
+        ```
         GET /ovirt-engine/api/disks/123/disksnapshots/789
-        ....
+        ```
 
         """
         return DiskSnapshotsService(self._connection, '%s/disksnapshots' % self._path)
@@ -40190,13 +42456,13 @@ class EngineKatelloErrataService(KatelloErrataService):
     ):
         """
         Retrieves the representation of the Katello errata.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/katelloerrata
-        ----
+        ```
         You will receive response in XML like this one:
-        [source,xml]
-        ----
+        
+        ```xml
         <katello_errata>
           <katello_erratum href="/ovirt-engine/api/katelloerrata/123" id="123">
             <name>RHBA-2013:XYZ</name>
@@ -40215,22 +42481,27 @@ class EngineKatelloErrataService(KatelloErrataService):
           </katello_erratum>
           ...
         </katello_errata>
-        ----
+        ```
         The order of the returned list of erratum isn't guaranteed.
 
 
         This method supports the following parameters:
 
-        `max`:: Sets the maximum number of errata to return. If not specified all the errata are returned.
+        `max` \n
+        Sets the maximum number of errata to return. If not specified all the errata are returned.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40278,8 +42549,8 @@ class EngineKatelloErrataService(KatelloErrataService):
 class ExternalHostProviderService(ExternalProviderService):
     """
     Represents an external host provider, such as Foreman or Satellite.
-    See link:https://www.theforeman.org/[Foreman documentation] for details.
-    See link:https://access.redhat.com/products/red-hat-satellite[Satellite documentation] for details.
+    See link:https://www.theforeman.org/ for details.
+    See link:https://access.redhat.com/products/red-hat-satellite for details.
 
     """
 
@@ -40304,31 +42575,35 @@ class ExternalHostProviderService(ExternalProviderService):
         Host provider, Foreman or Satellite, can be set as an external provider in ovirt. To see details about specific
         host providers attached to ovirt use this API.
         For example, to get the details of host provider `123`, send a request like this:
-        ....
+        ```
         GET /ovirt-engine/api/externalhostproviders/123
-        ....
+        ```
         The response will be like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <external_host_provider href="/ovirt-engine/api/externalhostproviders/123" id="123">
           <name>mysatellite</name>
           <requires_authentication>true</requires_authentication>
           <url>https://mysatellite.example.com</url>
           <username>admin</username>
         </external_host_provider>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40380,13 +42655,17 @@ class ExternalHostProviderService(ExternalProviderService):
         """
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40417,21 +42696,25 @@ class ExternalHostProviderService(ExternalProviderService):
         """
         In order to test connectivity for external provider we need
         to run following request where 123 is an id of a provider.
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/externalhostproviders/123/testconnectivity
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the test should be performed asynchronously.
+        `async_` \n
+        Indicates if the test should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40565,13 +42848,13 @@ class GlusterBrickService(MeasurableService):
         Retrieves status details of brick from underlying gluster volume with header `All-Content` set to `true`. This is
         the equivalent of running `gluster volume status <volumename> <brickname> detail`.
         For example, to get the details of brick `234` of gluster volume `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusters/567/glustervolumes/123/glusterbricks/234
-        ----
+        ```
         Which will return a response body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <brick id="234">
           <name>host1:/rhgs/data/brick1</name>
           <brick_dir>/rhgs/data/brick1</brick_dir>
@@ -40603,19 +42886,23 @@ class GlusterBrickService(MeasurableService):
           <pid>25589</pid>
           <port>49155</port>
         </brick>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40642,23 +42929,27 @@ class GlusterBrickService(MeasurableService):
         Removes a brick.
         Removes a brick from the underlying gluster volume and deletes entries from database. This can be used only when
         removing a single brick without data migration. To remove multiple bricks and with data migration, use
-        xref:services-gluster_bricks-methods-migrate[migrate] instead.
+        `GlusterBricksService.migrate` instead.
         For example, to delete brick `234` from gluster volume `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/clusters/567/glustervolumes/123/glusterbricks/234
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40690,19 +42981,23 @@ class GlusterBrickService(MeasurableService):
         """
         Replaces this brick with a new one.
         IMPORTANT: This operation has been deprecated since version 3.5 of the engine and will be removed in the future.
-        Use xref:services-gluster_bricks-methods-add[add brick(s)] and
-        xref:services-gluster_bricks-methods-migrate[migrate brick(s)] instead.
+        Use `GlusterBricksService.add` and
+        `GlusterBricksService.migrate` instead.
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the replacement should be performed asynchronously.
+        `async_` \n
+        Indicates if the replacement should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40766,13 +43061,13 @@ class GlusterVolumeService(MeasurableService):
         """
         Get the gluster volume details.
         For example, to get details of a gluster volume with identifier `123` in cluster `456`, send a request like this:
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/clusters/456/glustervolumes/123
-        ----
+        ```
         This GET request will return the following output:
-        [source,xml]
-        ----
+        
+        ```xml
         <gluster_volume id="123">
          <name>data</name>
          <link href="/ovirt-engine/api/clusters/456/glustervolumes/123/glusterbricks" rel="glusterbricks"/>
@@ -40800,19 +43095,23 @@ class GlusterVolumeService(MeasurableService):
          </transport_types>
          <volume_type>replicate</volume_type>
          </gluster_volume>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40838,10 +43137,10 @@ class GlusterVolumeService(MeasurableService):
         Get gluster volume profile statistics.
         For example, to get profile statistics for a gluster volume with identifier `123` in cluster `456`, send a
         request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/getprofilestatistics
-        ----
+        ```
 
 
         """
@@ -40873,28 +43172,34 @@ class GlusterVolumeService(MeasurableService):
         non-replicated volume, all bricks should be online to perform the rebalance operation. In a replicated volume, at
         least one of the bricks in the replica should be online.
         For example, to rebalance a gluster volume with identifier `123` in cluster `456`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/rebalance
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `fix_layout`:: If set to true, rebalance will only fix the layout so that new data added to the volume is distributed
+        `fix_layout` \n
+        If set to true, rebalance will only fix the layout so that new data added to the volume is distributed
         across all the hosts. But it will not migrate/rebalance the existing data. Default is `false`.
 
-        `force`:: Indicates if the rebalance should be force started. The rebalance command can be executed with the force
+        `force` \n
+        Indicates if the rebalance should be force started. The rebalance command can be executed with the force
         option even when the older clients are connected to the cluster. However, this could lead to a data loss
         situation. Default is `false`.
 
-        `async_`:: Indicates if the rebalance should be performed asynchronously.
+        `async_` \n
+        Indicates if the rebalance should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40928,21 +43233,25 @@ class GlusterVolumeService(MeasurableService):
         """
         Removes the gluster volume.
         For example, to remove a volume with identifier `123` in cluster `456`, send a request like this:
-        [source]
-        ----
+        
+        ```
         DELETE /ovirt-engine/api/clusters/456/glustervolumes/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -40974,21 +43283,25 @@ class GlusterVolumeService(MeasurableService):
         Resets all the options set in the gluster volume.
         For example, to reset all options in a gluster volume with identifier `123` in cluster `456`, send a request like
         this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/resetalloptions
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the reset should be performed asynchronously.
+        `async_` \n
+        Indicates if the reset should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41021,30 +43334,35 @@ class GlusterVolumeService(MeasurableService):
         Resets a particular option in the gluster volume.
         For example, to reset a particular option `option1` in a gluster volume with identifier `123` in cluster `456`,
         send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/resetoption
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
          <option name="option1"/>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `option`:: Option to reset.
+        `option` \n
+        Option to reset.
 
-        `async_`:: Indicates if the reset should be performed asynchronously.
+        `async_` \n
+        Indicates if the reset should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41080,30 +43398,35 @@ class GlusterVolumeService(MeasurableService):
         Sets a particular option in the gluster volume.
         For example, to set `option1` with value `value1` in a gluster volume with identifier `123` in cluster `456`,
         send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/setoption
-        ----
+        ```
         With the following request body:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
          <option name="option1" value="value1"/>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `option`:: Option to set.
+        `option` \n
+        Option to set.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41137,24 +43460,29 @@ class GlusterVolumeService(MeasurableService):
         Starts the gluster volume.
         A Gluster Volume should be started to read/write data. For example, to start a gluster volume with identifier
         `123` in cluster `456`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/start
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `force`:: Indicates if the volume should be force started. If a gluster volume is started already but few/all bricks
+        `force` \n
+        Indicates if the volume should be force started. If a gluster volume is started already but few/all bricks
         are down then force start can be used to bring all the bricks up. Default is `false`.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41186,21 +43514,25 @@ class GlusterVolumeService(MeasurableService):
         """
         Start profiling the gluster volume.
         For example, to start profiling a gluster volume with identifier `123` in cluster `456`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/startprofile
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41232,21 +43564,25 @@ class GlusterVolumeService(MeasurableService):
         Stops the gluster volume.
         Stopping a volume will make its data inaccessible.
         For example, to stop a gluster volume with identifier `123` in cluster `456`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/stop
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41278,21 +43614,25 @@ class GlusterVolumeService(MeasurableService):
         """
         Stop profiling the gluster volume.
         For example, to stop profiling a gluster volume with identifier `123` in cluster `456`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/stopprofile
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41323,21 +43663,25 @@ class GlusterVolumeService(MeasurableService):
         Stop rebalancing the gluster volume.
         For example, to stop rebalancing a gluster volume with identifier `123` in cluster `456`, send a request like
         this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/clusters/456/glustervolumes/123/stoprebalance
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41427,13 +43771,17 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the activation should be performed asynchronously.
+        `async_` \n
+        Indicates if the activation should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41471,23 +43819,31 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `host`:: The host to approve.
+        `host` \n
+        The host to approve.
 
-        `cluster`:: The cluster where the host will be added after it is approved.
+        `cluster` \n
+        The cluster where the host will be added after it is approved.
 
-        `async_`:: Indicates if the approval should be performed asynchronously.
+        `async_` \n
+        Indicates if the approval should be performed asynchronously.
 
-        `activate`:: When set to 'true', this host will be activated after its approval completes. When set to 'false'
+        `activate` \n
+        When set to 'true', this host will be activated after its approval completes. When set to 'false'
         the host will remain in 'maintenance' status after its approval. Absence of this parameter will be
         interpreted as 'true', since the desired default behavior is activating the host after approval.
 
-        `reboot`:: Indicates if the host should be rebooted after successful installation. The default value is `true`.
+        `reboot` \n
+        Indicates if the host should be rebooted after successful installation. The default value is `true`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41530,31 +43886,35 @@ class HostService(MeasurableService):
         not lost as a result of the configuration changes. If host connectivity is lost, the host requires a reboot and
         automatically reverts to the previous networking configuration.
         For example, to commit the network configuration of host with id `123` send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts/123/commitnetconfig
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
         IMPORTANT: Since {engine-name} 4.3, it is possible to also specify `commit_on_success` in
-        the xref:services-host-methods-setup_networks[setupnetworks] request, in which case the new
+        the `HostService.setup_networks` request, in which case the new
         configuration is automatically saved in the {hypervisor-name} upon completing the setup and
         re-establishing connectivity between the {hypervisor-name} and {engine-name}, and without
-        waiting for a separate xref:services-host-methods-commit_net_config[commitnetconfig] request.
+        waiting for a separate `HostService.commit_net_config` request.
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41587,30 +43947,35 @@ class HostService(MeasurableService):
         IMPORTANT: Any network attachments that are not present on the source host will be erased from the target host
         by the copy operation.
         To copy networks from another host, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts/123/copyhostnetworks
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
            <source_host id="456"/>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `source_host`:: The host to copy networks from.
+        `source_host` \n
+        The host to copy networks from.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41647,16 +44012,21 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the deactivation should be performed asynchronously.
+        `async_` \n
+        Indicates if the deactivation should be performed asynchronously.
 
-        `stop_gluster_service`:: Indicates if the gluster service should be stopped as part of deactivating the host. It can be used while
+        `stop_gluster_service` \n
+        Indicates if the gluster service should be stopped as part of deactivating the host. It can be used while
         performing maintenance operations on the gluster host. Default value for this variable is `false`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41693,22 +44063,22 @@ class HostService(MeasurableService):
         Returns a list of IscsiDetails objects containing the discovered data.
         For example, to discover iSCSI targets available in `myiscsi.example.com`,
         from host `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts/123/discoveriscsi
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <iscsi>
             <address>myiscsi.example.com</address>
           </iscsi>
         </action>
-        ----
+        ```
         The result will be like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <discovered_targets>
           <iscsi_details>
             <address>10.35.1.72</address>
@@ -41717,7 +44087,7 @@ class HostService(MeasurableService):
             <target>iqn.2015-08.com.tgt:444</target>
           </iscsi_details>
         </discovered_targets>
-        ----
+        ```
         IMPORTANT: When using this method to discover iscsi targets, you can use an FQDN or an
         IP address, but you must use the iscsi details from the discovered targets results to log in
         using the  iscsilogin method.
@@ -41725,15 +44095,20 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `iscsi`:: The target iSCSI device.
+        `iscsi` \n
+        The target iSCSI device.
 
-        `async_`:: Indicates if the discovery should be performed asynchronously.
+        `async_` \n
+        Indicates if the discovery should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41769,13 +44144,17 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the enrollment should be performed asynchronously.
+        `async_` \n
+        Indicates if the enrollment should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41807,8 +44186,8 @@ class HostService(MeasurableService):
         """
         Controls the host's power management device.
         For example, to start the host. This can be done via:
-        [source]
-        ----
+        
+        ```
         #!/bin/sh -ex
         url="https://engine.example.com/ovirt-engine/api"
         user="admin@internal"
@@ -41827,20 +44206,25 @@ class HostService(MeasurableService):
         </action>
         ' \
         "${url}/hosts/123/fence"
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the fencing should be performed asynchronously.
+        `async_` \n
+        Indicates if the fencing should be performed asynchronously.
 
-        `maintenance_after_restart`:: Indicates if host should be put into maintenance after restart.
+        `maintenance_after_restart` \n
+        Indicates if host should be put into maintenance after restart.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41873,26 +44257,30 @@ class HostService(MeasurableService):
     ):
         """
         To manually set a host as the storage pool manager (SPM).
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts/123/forceselectspm
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41923,35 +44311,41 @@ class HostService(MeasurableService):
     ):
         """
         Gets the host details.
-        [source]
-        ----
+        
+        ```
         GET /ovirt-engine/api/hosts/123
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `filter`:: Indicates if the results should be filtered according to the permissions of the user.
+        `filter` \n
+        Indicates if the results should be filtered according to the permissions of the user.
 
-        `all_content`:: Indicates if all of the attributes of the host should be included in the response.
+        `all_content` \n
+        Indicates if all of the attributes of the host should be included in the response.
         By default the following attributes are excluded:
         - `hosted_engine`
         For example, to retrieve the complete representation of host '123':
-        ....
+        ```
         GET /ovirt-engine/api/hosts/123?all_content=true
-        ....
+        ```
         NOTE: These attributes are not included by default because retrieving them impacts performance. They are
         seldom used and require additional queries to the database. Use this parameter with caution and only when
         specifically required.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -41996,8 +44390,8 @@ class HostService(MeasurableService):
         kdump configuration, hosted-engine deploy, kernel options changes, etc.
         The host type defines additional parameters for the action.
         Example of installing a host, using `curl` and JSON, plain:
-        [source,bash]
-        ----
+
+        ```bash
         curl \
         --verbose \
         --cacert /etc/pki/ovirt-engine/ca.pem \
@@ -42012,10 +44406,10 @@ class HostService(MeasurableService):
         }
         ' \
         "https://engine.example.com/ovirt-engine/api/hosts/123"
-        ----
+        ```
         Example of installing a host using `curl` and JSON with hosted engine components:
-        [source,bash]
-        ----
+
+        ```bash
         curl \
         curl \
         --verbose \
@@ -42032,43 +44426,55 @@ class HostService(MeasurableService):
         }
         ' \
         "https://engine.example.com/ovirt-engine/api/hosts/123"
-        ----
+        ```
         IMPORTANT: Since version 4.1.2 of the engine, when a host is reinstalled we override the host firewall
         definitions by default.
 
 
         This method supports the following parameters:
 
-        `activate`:: When set to 'true', this host will be activated after its installation completes. When set to 'false'
+        `activate` \n
+        When set to 'true', this host will be activated after its installation completes. When set to 'false'
         the host will remain in 'maintenance' status after its installation. Absence of this parameter will be
         interpreted as 'true', since the desired default behavior is activating the host after install.
 
-        `root_password`:: The password of the `root` user used to connect to the host via SSH.
+        `root_password` \n
+        The password of the `root` user used to connect to the host via SSH.
 
-        `ssh`:: The SSH details used to connect to the host.
+        `ssh` \n
+        The SSH details used to connect to the host.
 
-        `host`:: The `override_iptables` property is used to indicate if the firewall configuration should be replaced by the
+        `host` \n
+        The `override_iptables` property is used to indicate if the firewall configuration should be replaced by the
         default one.
 
-        `image`:: When installing {hypervisor-name}, an ISO image file is required.
+        `image` \n
+        When installing {hypervisor-name}, an ISO image file is required.
 
-        `async_`:: Indicates if the installation should be performed asynchronously.
+        `async_` \n
+        Indicates if the installation should be performed asynchronously.
 
-        `deploy_hosted_engine`:: When set to `true` this host will also deploy the self-hosted engine components. A missing value
+        `deploy_hosted_engine` \n
+        When set to `true` this host will also deploy the self-hosted engine components. A missing value
         is treated as `true` i.e deploy. Omitting this parameter means `false` and will not perform any operation in the
         self-hosted engine area.
 
-        `undeploy_hosted_engine`:: When set to `true` this host will un-deploy the self-hosted engine components, and this host will
+        `undeploy_hosted_engine` \n
+        When set to `true` this host will un-deploy the self-hosted engine components, and this host will
         not function as part of the High Availability cluster. A missing value is treated as `true` i.e un-deploy.
         Omitting this parameter means `false` and will not perform any operation in the self-hosted engine area.
 
-        `reboot`:: Indicates if the host should be rebooted after successful installation. The default value is `true`.
+        `reboot` \n
+        Indicates if the host should be rebooted after successful installation. The default value is `true`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42119,32 +44525,37 @@ class HostService(MeasurableService):
         Returns an array of strings containing the discovered data.
         For example, to discover iSCSI targets available in `myiscsi.example.com`,
         from host `123`, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts/123/iscsidiscover
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action>
           <iscsi>
             <address>myiscsi.example.com</address>
           </iscsi>
         </action>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `iscsi`:: The target iSCSI device.
+        `iscsi` \n
+        The target iSCSI device.
 
-        `async_`:: Indicates if the discovery should be performed asynchronously.
+        `async_` \n
+        Indicates if the discovery should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42182,15 +44593,20 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `iscsi`:: The target iSCSI device.
+        `iscsi` \n
+        The target iSCSI device.
 
-        `async_`:: Indicates if the login should be performed asynchronously.
+        `async_` \n
+        Indicates if the login should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42225,13 +44641,17 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the refresh should be performed asynchronously.
+        `async_` \n
+        Indicates if the refresh should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42261,8 +44681,8 @@ class HostService(MeasurableService):
     ):
         """
         Remove the host from the system.
-        [source]
-        ----
+        
+        ```
         #!/bin/sh -ex
         url="https://engine.example.com/ovirt-engine/api"
         user="admin@internal"
@@ -42274,21 +44694,26 @@ class HostService(MeasurableService):
         --request DELETE \
         --header "Version: 4" \
         "${url}/hosts/1ff7a191-2f3b-4eff-812b-9f91a30c3acc"
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `force`:: Indicates that the host should be removed even if it is non-responsive,
+        `force` \n
+        Indicates that the host should be removed even if it is non-responsive,
         or if it is part of a Gluster Storage cluster and has volume bricks on it.
 
-        `async_`:: Indicates if the remove should be performed asynchronously.
+        `async_` \n
+        Indicates if the remove should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42335,8 +44760,8 @@ class HostService(MeasurableService):
         For example, if you have a host with three network interfaces `eth0`, `eth1` and `eth2` and you want to configure
         a new bond using `eth0` and `eth1`, and put a VLAN on top of it. Using a simple shell script and the `curl`
         command line HTTP client that can be done as follows:
-        [source]
-        ----
+        
+        ```
         #!/bin/sh -ex
         url="https://engine.example.com/ovirt-engine/api"
         user="admin@internal"
@@ -42404,18 +44829,18 @@ class HostService(MeasurableService):
          </action>
         ' \
         "${url}/hosts/1ff7a191-2f3b-4eff-812b-9f91a30c3acc/setupnetworks"
-        ----
+        ```
         NOTE: This is valid for version 4 of the API. In previous versions some elements were represented as XML
         attributes instead of XML elements. In particular the `options` and `ip` elements were represented as follows:
-        [source,xml]
-        ----
+        
+        ```xml
         <options name="mode" value="4"/>
         <options name="miimon" value="100"/>
         <ip address="192.168.122.10" netmask="255.255.255.0"/>
-        ----
+        ```
         The same thing can be done using the Python SDK with the following code:
-        [source,python]
-        ----
+
+        ```python
         # Find the service that manages the collection of hosts:
         hosts_service = connection.system_service().hosts_service()
         # Find the host:
@@ -42479,34 +44904,38 @@ class HostService(MeasurableService):
         # After modifying the network configuration it is very important to make it
         # persistent:
         host_service.commit_net_config()
-        ----
+        ```
         IMPORTANT: To make sure that the network configuration has been saved in the host, and that it will be applied
-        when the host is rebooted, remember to call xref:services-host-methods-commit_net_config[commitnetconfig].
+        when the host is rebooted, remember to call `HostService.commit_net_config`.
         IMPORTANT: Since {engine-name} 4.3, it is possible to also specify `commit_on_success` in
-        the xref:services-host-methods-setup_networks[setupnetworks] request, in which case the new
-        configuration is automatically saved in the {hypervisor-name} upon completing the setup and
-        re-establishing connectivity between the {hypervisor-name} and {engine-name}, and without
-        waiting for a separate xref:services-host-methods-commit_net_config[commitnetconfig] request.
+        the `HostService.setup_networks` request, in which case the newconfiguration is automatically saved in 
+        the {hypervisor-name} upon completing the setup and re-establishing connectivity between the {hypervisor-name} 
+        and {engine-name}, and without waiting for a separate `HostService.commit_net_config` request.
 
 
         This method supports the following parameters:
 
-        `synchronized_network_attachments`:: A list of network attachments that will be synchronized.
+        `synchronized_network_attachments` \n
+        A list of network attachments that will be synchronized.
 
-        `commit_on_success`:: Specifies whether to automatically save the configuration in the {hypervisor-name} upon completing
+        `commit_on_success` \n
+        Specifies whether to automatically save the configuration in the {hypervisor-name} upon completing
         the setup and re-establishing connectivity between the {hypervisor-name} and {engine-name},
-        and without waiting for a separate xref:services-host-methods-commit_net_config[commitnetconfig]
-        request.
+        and without waiting for a separate `HostService.commit_net_config` request.
         The default value is `false`, which means that the configuration will not be
         saved automatically.
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42555,26 +44984,30 @@ class HostService(MeasurableService):
     ):
         """
         To synchronize all networks on the host, send a request like this:
-        [source]
-        ----
+        
+        ```
         POST /ovirt-engine/api/hosts/123/syncallnetworks
-        ----
+        ```
         With a request body like this:
-        [source,xml]
-        ----
+        
+        ```xml
         <action/>
-        ----
+        ```
 
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the action should be performed asynchronously.
+        `async_` \n
+        Indicates if the action should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42609,13 +45042,17 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the discovery should be performed asynchronously.
+        `async_` \n
+        Indicates if the discovery should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42648,19 +45085,19 @@ class HostService(MeasurableService):
         """
         Update the host properties.
         For example, to update a the kernel command line of a host send a request like this:
-        [source]
-        ----
+        
+        ```
         PUT /ovirt-engine/api/hosts/123
-        ----
+        ```
         With request body like this:
-        [source, xml]
-        ----
+
+        ```xml
         <host>
           <os>
             <custom_kernel_cmdline>vfio_iommu_type1.allow_unsafe_interrupts=1</custom_kernel_cmdline>
           </os>
         </host>
-        ----
+        ```
 
 
         """
@@ -42700,23 +45137,30 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `image`:: This property is no longer relevant, since Vintage Node is no longer supported, and has been deprecated.
+        `image` \n
+        This property is no longer relevant, since Vintage Node is no longer supported, and has been deprecated.
 
-        `reboot`:: Indicates if the host should be rebooted after the upgrade.
+        `reboot` \n
+        Indicates if the host should be rebooted after the upgrade.
         By default the host is rebooted.
         NOTE: This parameter is ignored for {hypervisor-name}, which is always rebooted after the upgrade.
 
-        `async_`:: Indicates if the upgrade should be performed asynchronously.
+        `async_` \n
+        Indicates if the upgrade should be performed asynchronously.
 
-        `timeout`:: Upgrade timeout.
+        `timeout` \n
+        Upgrade timeout.
         The maximum time to wait for upgrade to finish in minutes.
         Default value is specified by `ANSIBLE_PLAYBOOK_EXEC_DEFAULT_TIMEOUT` configration option.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42752,7 +45196,7 @@ class HostService(MeasurableService):
         Check if there are upgrades available for the host. If there are upgrades available an icon will be displayed
         next to host status icon in the Administration Portal. Audit log messages are also added to indicate the
         availability of upgrades. The upgrade can be started from the webadmin or by using the
-        xref:services-host-methods-upgrade[upgrade] host action.
+        `HostService.upgrade` host action.
 
 
         """
@@ -42782,23 +45226,31 @@ class HostService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `host`:: The host to approve.
+        `host` \n
+        The host to approve.
 
-        `cluster`:: The cluster where the host will be added after it is approved.
+        `cluster` \n
+        The cluster where the host will be added after it is approved.
 
-        `async_`:: Indicates if the approval should be performed asynchronously.
+        `async_` \n
+        Indicates if the approval should be performed asynchronously.
 
-        `activate`:: When set to 'true', this host will be activated after its approval completes. When set to 'false'
+        `activate` \n
+        When set to 'true', this host will be activated after its approval completes. When set to 'false'
         the host will remain in 'maintenance' status after its approval. Absence of this parameter will be
         interpreted as 'true', since the desired default behavior is activating the host after approval.
 
-        `reboot`:: Indicates if the host should be rebooted after successful installation. The default value is `true`.
+        `reboot` \n
+        Indicates if the host should be rebooted after successful installation. The default value is `true`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42848,36 +45300,48 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `activate`:: When set to 'true', this host will be activated after its installation completes. When set to 'false'
+        `activate` \n
+        When set to 'true', this host will be activated after its installation completes. When set to 'false'
         the host will remain in 'maintenance' status after its installation. Absence of this parameter will be
         interpreted as 'true', since the desired default behavior is activating the host after install.
 
-        `root_password`:: The password of the `root` user used to connect to the host via SSH.
+        `root_password` \n
+        The password of the `root` user used to connect to the host via SSH.
 
-        `ssh`:: The SSH details used to connect to the host.
+        `ssh` \n
+        The SSH details used to connect to the host.
 
-        `host`:: The `override_iptables` property is used to indicate if the firewall configuration should be replaced by the
+        `host` \n
+        The `override_iptables` property is used to indicate if the firewall configuration should be replaced by the
         default one.
 
-        `image`:: When installing {hypervisor-name}, an ISO image file is required.
+        `image` \n
+        When installing {hypervisor-name}, an ISO image file is required.
 
-        `async_`:: Indicates if the installation should be performed asynchronously.
+        `async_` \n
+        Indicates if the installation should be performed asynchronously.
 
-        `deploy_hosted_engine`:: When set to `true` this host will also deploy the self-hosted engine components. A missing value
+        `deploy_hosted_engine` \n
+        When set to `true` this host will also deploy the self-hosted engine components. A missing value
         is treated as `true` i.e deploy. Omitting this parameter means `false` and will not perform any operation in the
         self-hosted engine area.
 
-        `undeploy_hosted_engine`:: When set to `true` this host will un-deploy the self-hosted engine components, and this host will
+        `undeploy_hosted_engine` \n
+        When set to `true` this host will un-deploy the self-hosted engine components, and this host will
         not function as part of the High Availability cluster. A missing value is treated as `true` i.e un-deploy.
         Omitting this parameter means `false` and will not perform any operation in the self-hosted engine area.
 
-        `reboot`:: Indicates if the host should be rebooted after successful installation. The default value is `true`.
+        `reboot` \n
+        Indicates if the host should be rebooted after successful installation. The default value is `true`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -42964,23 +45428,31 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `host`:: The host to approve.
+        `host` \n
+        The host to approve.
 
-        `cluster`:: The cluster where the host will be added after it is approved.
+        `cluster` \n
+        The cluster where the host will be added after it is approved.
 
-        `async_`:: Indicates if the approval should be performed asynchronously.
+        `async_` \n
+        Indicates if the approval should be performed asynchronously.
 
-        `activate`:: When set to 'true', this host will be activated after its approval completes. When set to 'false'
+        `activate` \n
+        When set to 'true', this host will be activated after its approval completes. When set to 'false'
         the host will remain in 'maintenance' status after its approval. Absence of this parameter will be
         interpreted as 'true', since the desired default behavior is activating the host after approval.
 
-        `reboot`:: Indicates if the host should be rebooted after successful installation. The default value is `true`.
+        `reboot` \n
+        Indicates if the host should be rebooted after successful installation. The default value is `true`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -43030,36 +45502,48 @@ class HostService(MeasurableService):
 
         This method supports the following parameters:
 
-        `activate`:: When set to 'true', this host will be activated after its installation completes. When set to 'false'
+        `activate` \n
+        When set to 'true', this host will be activated after its installation completes. When set to 'false'
         the host will remain in 'maintenance' status after its installation. Absence of this parameter will be
         interpreted as 'true', since the desired default behavior is activating the host after install.
 
-        `root_password`:: The password of the `root` user used to connect to the host via SSH.
+        `root_password` \n
+        The password of the `root` user used to connect to the host via SSH.
 
-        `ssh`:: The SSH details used to connect to the host.
+        `ssh` \n
+        The SSH details used to connect to the host.
 
-        `host`:: The `override_iptables` property is used to indicate if the firewall configuration should be replaced by the
+        `host` \n
+        The `override_iptables` property is used to indicate if the firewall configuration should be replaced by the
         default one.
 
-        `image`:: When installing {hypervisor-name}, an ISO image file is required.
+        `image` \n
+        When installing {hypervisor-name}, an ISO image file is required.
 
-        `async_`:: Indicates if the installation should be performed asynchronously.
+        `async_` \n
+        Indicates if the installation should be performed asynchronously.
 
-        `deploy_hosted_engine`:: When set to `true` this host will also deploy the self-hosted engine components. A missing value
+        `deploy_hosted_engine` \n
+        When set to `true` this host will also deploy the self-hosted engine components. A missing value
         is treated as `true` i.e deploy. Omitting this parameter means `false` and will not perform any operation in the
         self-hosted engine area.
 
-        `undeploy_hosted_engine`:: When set to `true` this host will un-deploy the self-hosted engine components, and this host will
+        `undeploy_hosted_engine` \n
+        When set to `true` this host will un-deploy the self-hosted engine components, and this host will
         not function as part of the High Availability cluster. A missing value is treated as `true` i.e un-deploy.
         Omitting this parameter means `false` and will not perform any operation in the self-hosted engine area.
 
-        `reboot`:: Indicates if the host should be rebooted after successful installation. The default value is `true`.
+        `reboot` \n
+        Indicates if the host should be rebooted after successful installation. The default value is `true`.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -43346,25 +45830,30 @@ class HostNicService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `all_content`:: Indicates if all of the attributes of the host network interface should be included in the response.
+        `all_content` \n
+        Indicates if all of the attributes of the host network interface should be included in the response.
         By default the following attributes are excluded:
         - `virtual_functions_configuration`
         For example, to retrieve the complete representation network interface '456' of host '123':
-        ....
+        ```
         GET /ovirt-engine/api/hosts/123/nics/456?all_content=true
-        ....
+        ```
         NOTE: These attributes are not included by default because retrieving them impacts performance. They are
         seldom used and require additional queries to the database. Use this parameter with caution and only when
         specifically required.
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -43402,13 +45891,17 @@ class HostNicService(MeasurableService):
 
         This method supports the following parameters:
 
-        `async_`:: Indicates if the update should be performed asynchronously.
+        `async_` \n
+        Indicates if the update should be performed asynchronously.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([
@@ -43526,14 +46019,18 @@ class HostNumaNodeService(MeasurableService):
         """
         This method supports the following parameters:
 
-        `follow`:: Indicates which inner links should be _followed_. The objects referenced by these links will be fetched as part
-        of the current request. See <<documents/003_common_concepts/follow, here>> for details.
+        `follow` \n
+        Indicates which inner links should be followed. The objects referenced by these links will be fetched as part
+        of the current request.
 
-        `headers`:: Additional HTTP headers.
+        `headers` \n
+        Additional HTTP headers.
 
-        `query`:: Additional URL query parameters.
+        `query` \n
+        Additional URL query parameters.
 
-        `wait`:: If `True` wait for the response.
+        `wait` \n
+        If `True` wait for the response.
         """
         # Check the types of the parameters:
         Service._check_types([

--- a/lib/ovirtsdk4/types.py
+++ b/lib/ovirtsdk4/types.py
@@ -22,6 +22,8 @@ from ovirtsdk4 import Struct
 
 
 class AffinityRule(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -79,6 +81,8 @@ class AffinityRule(Struct):
 
 
 class AgentConfiguration(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -185,6 +189,8 @@ class AgentConfiguration(Struct):
 
 
 class Api(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -295,6 +301,8 @@ class Api(Struct):
 
 
 class ApiSummary(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -372,6 +380,8 @@ class ApiSummary(Struct):
 
 
 class ApiSummaryItem(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -413,6 +423,8 @@ class ApiSummaryItem(Struct):
 
 
 class Bios(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -456,6 +468,8 @@ class Bios(Struct):
 
 
 class BlockStatistic(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -481,6 +495,8 @@ class BlockStatistic(Struct):
 
 
 class Bonding(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -556,6 +572,8 @@ class Bonding(Struct):
 
 
 class Boot(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -581,6 +599,8 @@ class Boot(Struct):
 
 
 class BootMenu(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -606,6 +626,8 @@ class BootMenu(Struct):
 
 
 class CloudInit(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -729,6 +751,8 @@ class CloudInit(Struct):
 
 
 class Configuration(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -771,6 +795,8 @@ class Configuration(Struct):
 
 
 class Console(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -796,6 +822,8 @@ class Console(Struct):
 
 
 class Core(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -837,6 +865,8 @@ class Core(Struct):
 
 
 class Cpu(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -994,6 +1024,8 @@ class Cpu(Struct):
 
 
 class CpuTopology(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1051,6 +1083,8 @@ class CpuTopology(Struct):
 
 
 class CpuTune(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1076,6 +1110,8 @@ class CpuTune(Struct):
 
 
 class CpuType(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1134,6 +1170,8 @@ class CpuType(Struct):
 
 
 class CustomProperty(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1191,6 +1229,8 @@ class CustomProperty(Struct):
 
 
 class Display(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1442,6 +1482,8 @@ class Display(Struct):
 
 
 class Dns(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1483,6 +1525,8 @@ class Dns(Struct):
 
 
 class DnsResolverConfiguration(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1508,6 +1552,8 @@ class DnsResolverConfiguration(Struct):
 
 
 class DynamicCpu(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1551,6 +1597,8 @@ class DynamicCpu(Struct):
 
 
 class EntityProfileDetail(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1576,6 +1624,8 @@ class EntityProfileDetail(Struct):
 
 
 class ErrorHandling(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1602,6 +1652,8 @@ class ErrorHandling(Struct):
 
 
 class ExternalTemplateImport(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1745,6 +1797,8 @@ class ExternalTemplateImport(Struct):
 
 
 class ExternalVmImport(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -1970,6 +2024,8 @@ class ExternalVmImport(Struct):
 
 
 class Fault(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2011,6 +2067,8 @@ class Fault(Struct):
 
 
 class FencingPolicy(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2102,6 +2160,8 @@ class FencingPolicy(Struct):
 
 
 class FopStatistic(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2143,6 +2203,8 @@ class FopStatistic(Struct):
 
 
 class GlusterBrickMemoryInfo(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2168,6 +2230,8 @@ class GlusterBrickMemoryInfo(Struct):
 
 
 class GlusterClient(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2241,6 +2305,8 @@ class GlusterClient(Struct):
 
 
 class GracePeriod(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2266,6 +2332,8 @@ class GracePeriod(Struct):
 
 
 class GuestOperatingSystem(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2373,6 +2441,8 @@ class GuestOperatingSystem(Struct):
 
 
 class HardwareInformation(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2494,6 +2564,8 @@ class HardwareInformation(Struct):
 
 
 class HighAvailability(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2535,6 +2607,8 @@ class HighAvailability(Struct):
 
 
 class HostDevicePassthrough(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2560,6 +2634,8 @@ class HostDevicePassthrough(Struct):
 
 
 class HostNicVirtualFunctionsConfiguration(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2617,6 +2693,8 @@ class HostNicVirtualFunctionsConfiguration(Struct):
 
 
 class HostedEngine(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2706,6 +2784,8 @@ class HostedEngine(Struct):
 
 
 class Identified(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -2779,6 +2859,8 @@ class Identified(Struct):
 
 
 class Image(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -2846,6 +2928,8 @@ class Image(Identified):
 
 
 class ImageTransfer(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -3112,6 +3196,8 @@ class ImageTransfer(Identified):
 
 
 class Initialization(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -3476,6 +3562,8 @@ class Initialization(Struct):
 
 
 class Io(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -3501,6 +3589,8 @@ class Io(Struct):
 
 
 class Ip(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -3575,6 +3665,8 @@ class Ip(Struct):
 
 
 class IpAddressAssignment(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -3618,6 +3710,8 @@ class IpAddressAssignment(Struct):
 
 
 class IscsiBond(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -3684,6 +3778,8 @@ class IscsiBond(Identified):
 
 
 class IscsiDetails(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -3965,6 +4061,8 @@ class IscsiDetails(Struct):
 
 
 class Job(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -4112,6 +4210,8 @@ class Job(Identified):
 
 
 class KatelloErratum(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -4275,6 +4375,8 @@ class KatelloErratum(Identified):
 
 
 class Kernel(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -4301,6 +4403,8 @@ class Kernel(Struct):
 
 
 class Ksm(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -4342,6 +4446,8 @@ class Ksm(Struct):
 
 
 class LinkLayerDiscoveryProtocolElement(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -4423,6 +4529,8 @@ class LinkLayerDiscoveryProtocolElement(Identified):
 
 
 class LogicalUnit(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -4737,6 +4845,8 @@ class LogicalUnit(Struct):
 
 
 class MDevType(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -4810,6 +4920,8 @@ class MDevType(Struct):
 
 
 class Mac(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -4835,6 +4947,8 @@ class Mac(Struct):
 
 
 class MacPool(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -4916,6 +5030,8 @@ class MacPool(Identified):
 
 
 class MemoryOverCommit(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -4941,6 +5057,8 @@ class MemoryOverCommit(Struct):
 
 
 class MemoryPolicy(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -5032,6 +5150,8 @@ class MemoryPolicy(Struct):
 
 
 class Method(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -5058,6 +5178,8 @@ class Method(Struct):
 
 
 class MigrationBandwidth(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -5100,6 +5222,8 @@ class MigrationBandwidth(Struct):
 
 
 class MigrationOptions(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -5227,6 +5351,8 @@ class MigrationOptions(Struct):
 
 
 class MigrationPolicy(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -5245,6 +5371,8 @@ class MigrationPolicy(Identified):
 
 
 class Network(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -5591,6 +5719,8 @@ class Network(Identified):
 
 
 class NetworkAttachment(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -5757,6 +5887,8 @@ class NetworkAttachment(Identified):
 
 
 class NetworkConfiguration(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -5799,6 +5931,8 @@ class NetworkConfiguration(Struct):
 
 
 class NetworkFilter(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -5833,6 +5967,8 @@ class NetworkFilter(Identified):
 
 
 class NetworkFilterParameter(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -5883,6 +6019,8 @@ class NetworkFilterParameter(Identified):
 
 
 class NetworkLabel(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -5934,6 +6072,8 @@ class NetworkLabel(Identified):
 
 
 class NfsProfileDetail(EntityProfileDetail):
+    """
+    """
 
     def __init__(
         self,
@@ -5961,6 +6101,8 @@ class NfsProfileDetail(EntityProfileDetail):
 
 
 class NicConfiguration(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -6070,6 +6212,8 @@ class NicConfiguration(Struct):
 
 
 class NumaNode(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -6185,6 +6329,8 @@ class NumaNode(Identified):
 
 
 class NumaNodePin(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -6243,6 +6389,8 @@ class NumaNodePin(Struct):
 
 
 class OpenStackImage(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -6277,6 +6425,8 @@ class OpenStackImage(Identified):
 
 
 class OpenStackNetwork(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -6311,6 +6461,8 @@ class OpenStackNetwork(Identified):
 
 
 class OpenStackSubnet(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -6409,6 +6561,8 @@ class OpenStackSubnet(Identified):
 
 
 class OpenStackVolumeType(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -6459,6 +6613,8 @@ class OpenStackVolumeType(Identified):
 
 
 class OpenstackVolumeAuthenticationKey(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -6558,6 +6714,8 @@ class OpenstackVolumeAuthenticationKey(Identified):
 
 
 class OperatingSystem(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -6697,6 +6855,8 @@ class OperatingSystem(Struct):
 
 
 class OperatingSystemInfo(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -6782,6 +6942,8 @@ class OperatingSystemInfo(Identified):
 
 
 class Option(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -6839,6 +7001,8 @@ class Option(Struct):
 
 
 class Package(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -6864,6 +7028,8 @@ class Package(Struct):
 
 
 class Payload(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -6922,6 +7088,8 @@ class Payload(Struct):
 
 
 class Permission(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -7126,6 +7294,8 @@ class Permission(Identified):
 
 
 class Permit(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -7176,6 +7346,8 @@ class Permit(Identified):
 
 
 class PmProxy(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -7202,6 +7374,8 @@ class PmProxy(Struct):
 
 
 class PortMirroring(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -7212,6 +7386,8 @@ class PortMirroring(Struct):
 
 
 class PowerManagement(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -7398,6 +7574,8 @@ class PowerManagement(Struct):
 
 
 class Product(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -7416,6 +7594,8 @@ class Product(Identified):
 
 
 class ProductInfo(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -7490,6 +7670,8 @@ class ProductInfo(Struct):
 
 
 class ProfileDetail(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -7579,6 +7761,8 @@ class ProfileDetail(Struct):
 
 
 class Property(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -7620,6 +7804,8 @@ class Property(Struct):
 
 
 class ProxyTicket(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -7645,6 +7831,8 @@ class ProxyTicket(Struct):
 
 
 class Qos(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -7952,6 +8140,8 @@ class Qos(Identified):
 
 
 class Quota(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -8146,6 +8336,8 @@ class Quota(Identified):
 
 
 class QuotaClusterLimit(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -8261,6 +8453,8 @@ class QuotaClusterLimit(Identified):
 
 
 class QuotaStorageLimit(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -8344,6 +8538,8 @@ class QuotaStorageLimit(Identified):
 
 
 class Range(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8385,6 +8581,8 @@ class Range(Struct):
 
 
 class Rate(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8426,6 +8624,8 @@ class Rate(Struct):
 
 
 class RegistrationAffinityGroupMapping(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8469,6 +8669,8 @@ class RegistrationAffinityGroupMapping(Struct):
 
 
 class RegistrationAffinityLabelMapping(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8512,6 +8714,8 @@ class RegistrationAffinityLabelMapping(Struct):
 
 
 class RegistrationClusterMapping(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8555,6 +8759,8 @@ class RegistrationClusterMapping(Struct):
 
 
 class RegistrationConfiguration(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8676,6 +8882,8 @@ class RegistrationConfiguration(Struct):
 
 
 class RegistrationDomainMapping(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8719,6 +8927,8 @@ class RegistrationDomainMapping(Struct):
 
 
 class RegistrationLunMapping(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8762,6 +8972,8 @@ class RegistrationLunMapping(Struct):
 
 
 class RegistrationRoleMapping(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8805,6 +9017,8 @@ class RegistrationRoleMapping(Struct):
 
 
 class RegistrationVnicProfileMapping(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8848,6 +9062,8 @@ class RegistrationVnicProfileMapping(Struct):
 
 
 class ReportedConfiguration(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -8921,6 +9137,8 @@ class ReportedConfiguration(Struct):
 
 
 class ReportedDevice(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -9005,6 +9223,8 @@ class ReportedDevice(Identified):
 
 
 class RngDevice(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -9048,6 +9268,8 @@ class RngDevice(Struct):
 
 
 class Role(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -9130,6 +9352,8 @@ class Role(Identified):
 
 
 class SchedulingPolicy(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -9243,6 +9467,8 @@ class SchedulingPolicy(Identified):
 
 
 class SchedulingPolicyUnit(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -9325,6 +9551,8 @@ class SchedulingPolicyUnit(Identified):
 
 
 class SeLinux(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -9351,6 +9579,8 @@ class SeLinux(Struct):
 
 
 class SerialNumber(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -9393,6 +9623,8 @@ class SerialNumber(Struct):
 
 
 class Session(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -9493,6 +9725,8 @@ class Session(Identified):
 
 
 class SkipIfConnectivityBroken(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -9534,6 +9768,8 @@ class SkipIfConnectivityBroken(Struct):
 
 
 class SkipIfSdActive(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -9559,6 +9795,8 @@ class SkipIfSdActive(Struct):
 
 
 class SpecialObjects(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -9602,6 +9840,8 @@ class SpecialObjects(Struct):
 
 
 class Spm(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -9644,6 +9884,8 @@ class Spm(Struct):
 
 
 class Ssh(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -9743,6 +9985,8 @@ class Ssh(Identified):
 
 
 class SshPublicKey(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -9793,6 +10037,8 @@ class SshPublicKey(Identified):
 
 
 class Sso(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -9818,6 +10064,8 @@ class Sso(Struct):
 
 
 class Statistic(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -10055,6 +10303,8 @@ class Statistic(Identified):
 
 
 class Step(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -10270,6 +10520,8 @@ class Step(Identified):
 
 
 class StorageConnection(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -10531,6 +10783,8 @@ class StorageConnection(Identified):
 
 
 class StorageConnectionExtension(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -10613,6 +10867,8 @@ class StorageConnectionExtension(Identified):
 
 
 class StorageDomain(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -11117,6 +11373,8 @@ class StorageDomain(Identified):
 
 
 class StorageDomainLease(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -11143,6 +11401,8 @@ class StorageDomainLease(Struct):
 
 
 class SystemOption(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -11176,6 +11436,8 @@ class SystemOption(Identified):
 
 
 class SystemOptionValue(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -11217,6 +11479,8 @@ class SystemOptionValue(Struct):
 
 
 class Tag(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -11336,6 +11600,8 @@ class Tag(Identified):
 
 
 class TemplateVersion(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -11394,6 +11660,8 @@ class TemplateVersion(Struct):
 
 
 class Ticket(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -11435,6 +11703,8 @@ class Ticket(Struct):
 
 
 class TimeZone(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -11476,6 +11746,8 @@ class TimeZone(Struct):
 
 
 class TransparentHugePages(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -11501,6 +11773,8 @@ class TransparentHugePages(Struct):
 
 
 class UnmanagedNetwork(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -11552,6 +11826,8 @@ class UnmanagedNetwork(Identified):
 
 
 class Usb(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -11594,6 +11870,8 @@ class Usb(Struct):
 
 
 class User(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -11884,6 +12162,8 @@ class User(Identified):
 
 
 class UserOption(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -11934,6 +12214,8 @@ class UserOption(Identified):
 
 
 class Value(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -11975,6 +12257,8 @@ class Value(Struct):
 
 
 class VcpuPin(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -12016,6 +12300,8 @@ class VcpuPin(Struct):
 
 
 class Vendor(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -12034,6 +12320,8 @@ class Vendor(Identified):
 
 
 class Version(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -12131,6 +12419,8 @@ class Version(Identified):
 
 
 class VirtioScsi(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -12156,6 +12446,8 @@ class VirtioScsi(Struct):
 
 
 class VirtualNumaNode(NumaNode):
+    """
+    """
 
     def __init__(
         self,
@@ -12235,6 +12527,8 @@ class VirtualNumaNode(NumaNode):
 
 
 class Vlan(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -12260,6 +12554,8 @@ class Vlan(Struct):
 
 
 class VmBase(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -13059,6 +13355,8 @@ class VmBase(Identified):
 
 
 class VmPlacementPolicy(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -13101,6 +13399,8 @@ class VmPlacementPolicy(Struct):
 
 
 class VmPool(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -13381,6 +13681,8 @@ class VmPool(Identified):
 
 
 class VmSummary(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -13438,6 +13740,8 @@ class VmSummary(Struct):
 
 
 class VnicPassThrough(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -13464,6 +13768,8 @@ class VnicPassThrough(Struct):
 
 
 class VnicProfile(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -13630,6 +13936,8 @@ class VnicProfile(Identified):
 
 
 class VnicProfileMapping(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -13688,6 +13996,8 @@ class VnicProfileMapping(Struct):
 
 
 class VolumeGroup(Struct):
+    """
+    """
 
     def __init__(
         self,
@@ -13745,6 +14055,8 @@ class VolumeGroup(Struct):
 
 
 class Weight(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -13812,6 +14124,8 @@ class Weight(Identified):
 
 
 class Action(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -15348,6 +15662,8 @@ class Action(Identified):
 
 
 class AffinityGroup(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -15544,6 +15860,8 @@ class AffinityGroup(Identified):
 
 
 class AffinityLabel(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -15625,6 +15943,8 @@ class AffinityLabel(Identified):
 
 
 class Agent(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -15803,6 +16123,8 @@ class Agent(Identified):
 
 
 class Application(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -15837,6 +16159,8 @@ class Application(Identified):
 
 
 class AuthorizedKey(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -15887,6 +16211,8 @@ class AuthorizedKey(Identified):
 
 
 class Backup(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -16052,6 +16378,8 @@ class Backup(Identified):
 
 
 class Balance(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -16103,6 +16431,8 @@ class Balance(Identified):
 
 
 class Bookmark(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -16136,6 +16466,8 @@ class Bookmark(Identified):
 
 
 class BrickProfileDetail(EntityProfileDetail):
+    """
+    """
 
     def __init__(
         self,
@@ -16164,6 +16496,8 @@ class BrickProfileDetail(EntityProfileDetail):
 
 
 class Certificate(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -16229,6 +16563,8 @@ class Certificate(Identified):
 
 
 class Checkpoint(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -16328,6 +16664,8 @@ class Checkpoint(Identified):
 
 
 class Cluster(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -17083,6 +17421,8 @@ class Cluster(Identified):
 
 
 class ClusterFeature(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -17117,6 +17457,8 @@ class ClusterFeature(Identified):
 
 
 class ClusterLevel(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -17182,6 +17524,8 @@ class ClusterLevel(Identified):
 
 
 class CpuProfile(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -17249,6 +17593,8 @@ class CpuProfile(Identified):
 
 
 class DataCenter(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -17495,6 +17841,8 @@ class DataCenter(Identified):
 
 
 class Device(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -17579,6 +17927,8 @@ class Device(Identified):
 
 
 class Disk(Device):
+    """
+    """
 
     def __init__(
         self,
@@ -18179,6 +18529,8 @@ class Disk(Device):
 
 
 class DiskAttachment(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -18360,6 +18712,8 @@ class DiskAttachment(Identified):
 
 
 class DiskProfile(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -18427,6 +18781,8 @@ class DiskProfile(Identified):
 
 
 class DiskSnapshot(Disk):
+    """
+    """
 
     def __init__(
         self,
@@ -18556,6 +18912,8 @@ class DiskSnapshot(Disk):
 
 
 class Domain(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -18622,6 +18980,8 @@ class Domain(Identified):
 
 
 class Event(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -18919,6 +19279,8 @@ class Event(Identified):
 
 
 class EventSubscription(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19003,6 +19365,8 @@ class EventSubscription(Identified):
 
 
 class ExternalComputeResource(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19085,6 +19449,8 @@ class ExternalComputeResource(Identified):
 
 
 class ExternalDiscoveredHost(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19183,6 +19549,8 @@ class ExternalDiscoveredHost(Identified):
 
 
 class ExternalHost(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19233,6 +19601,8 @@ class ExternalHost(Identified):
 
 
 class ExternalHostGroup(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19331,6 +19701,8 @@ class ExternalHostGroup(Identified):
 
 
 class ExternalNetworkProviderConfiguration(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19382,6 +19754,8 @@ class ExternalNetworkProviderConfiguration(Identified):
 
 
 class ExternalProvider(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19495,6 +19869,8 @@ class ExternalProvider(Identified):
 
 
 class File(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19561,6 +19937,8 @@ class File(Identified):
 
 
 class Filter(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19611,6 +19989,8 @@ class Filter(Identified):
 
 
 class Floppy(Device):
+    """
+    """
 
     def __init__(
         self,
@@ -19653,6 +20033,8 @@ class Floppy(Device):
 
 
 class GlusterBrickAdvancedDetails(Device):
+    """
+    """
 
     def __init__(
         self,
@@ -19790,6 +20172,8 @@ class GlusterBrickAdvancedDetails(Device):
 
 
 class GlusterHook(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -19971,6 +20355,8 @@ class GlusterHook(Identified):
 
 
 class GlusterMemoryPool(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -20116,6 +20502,8 @@ class GlusterMemoryPool(Identified):
 
 
 class GlusterServerHook(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -20200,6 +20588,8 @@ class GlusterServerHook(Identified):
 
 
 class GlusterVolume(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -20396,6 +20786,8 @@ class GlusterVolume(Identified):
 
 
 class GlusterVolumeProfileDetails(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -20445,6 +20837,8 @@ class GlusterVolumeProfileDetails(Identified):
 
 
 class GraphicsConsole(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -20578,6 +20972,8 @@ class GraphicsConsole(Identified):
 
 
 class Group(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -20692,6 +21088,8 @@ class Group(Identified):
 
 
 class Hook(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -20758,6 +21156,8 @@ class Hook(Identified):
 
 
 class Host(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -21665,6 +22065,8 @@ class Host(Identified):
 
 
 class HostCpuUnit(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -21762,6 +22164,8 @@ class HostCpuUnit(Identified):
 
 
 class HostDevice(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -21977,6 +22381,8 @@ class HostDevice(Identified):
 
 
 class HostNic(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -22391,6 +22797,8 @@ class HostNic(Identified):
 
 
 class HostStorage(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -22716,6 +23124,8 @@ class HostStorage(Identified):
 
 
 class Icon(Identified):
+    """
+    """
 
     def __init__(
         self,
@@ -22765,6 +23175,8 @@ class Icon(Identified):
 
 
 class Nic(Device):
+    """
+    """
 
     def __init__(
         self,
@@ -23051,6 +23463,8 @@ class Nic(Device):
 
 
 class OpenStackProvider(ExternalProvider):
+    """
+    """
 
     def __init__(
         self,
@@ -23096,6 +23510,8 @@ class OpenStackProvider(ExternalProvider):
 
 
 class OpenStackVolumeProvider(OpenStackProvider):
+    """
+    """
 
     def __init__(
         self,
@@ -23192,6 +23608,8 @@ class OpenStackVolumeProvider(OpenStackProvider):
 
 
 class Template(VmBase):
+    """
+    """
 
     def __init__(
         self,
@@ -23482,6 +23900,8 @@ class Template(VmBase):
 
 
 class Vm(VmBase):
+    """
+    """
 
     def __init__(
         self,
@@ -24228,6 +24648,8 @@ class Vm(VmBase):
 
 
 class VmMediatedDevice(Device):
+    """
+    """
 
     def __init__(
         self,
@@ -24269,6 +24691,8 @@ class VmMediatedDevice(Device):
 
 
 class Watchdog(Device):
+    """
+    """
 
     def __init__(
         self,
@@ -24328,6 +24752,8 @@ class Watchdog(Device):
 
 
 class Cdrom(Device):
+    """
+    """
 
     def __init__(
         self,
@@ -24370,6 +24796,8 @@ class Cdrom(Device):
 
 
 class ExternalHostProvider(ExternalProvider):
+    """
+    """
 
     def __init__(
         self,
@@ -24479,6 +24907,8 @@ class ExternalHostProvider(ExternalProvider):
 
 
 class GlusterBrick(GlusterBrickAdvancedDetails):
+    """
+    """
 
     def __init__(
         self,
@@ -24600,6 +25030,8 @@ class GlusterBrick(GlusterBrickAdvancedDetails):
 
 
 class InstanceType(Template):
+    """
+    """
 
     def __init__(
         self,
@@ -24734,6 +25166,8 @@ class InstanceType(Template):
 
 
 class OpenStackImageProvider(OpenStackProvider):
+    """
+    """
 
     def __init__(
         self,
@@ -24797,6 +25231,8 @@ class OpenStackImageProvider(OpenStackProvider):
 
 
 class OpenStackNetworkProvider(OpenStackProvider):
+    """
+    """
 
     def __init__(
         self,
@@ -25039,6 +25475,8 @@ class OpenStackNetworkProvider(OpenStackProvider):
 
 
 class Snapshot(Vm):
+    """
+    """
 
     def __init__(
         self,
@@ -25328,6 +25766,8 @@ class Snapshot(Vm):
 
 @unique
 class AccessProtocol(Enum):
+    """
+    """
     CIFS = 'cifs'
     GLUSTER = 'gluster'
     NFS = 'nfs'
@@ -25341,6 +25781,8 @@ class AccessProtocol(Enum):
 
 @unique
 class Architecture(Enum):
+    """
+    """
     AARCH64 = 'aarch64'
     LOONGARCH64 = 'loongarch64'
     PPC64 = 'ppc64'
@@ -25357,6 +25799,8 @@ class Architecture(Enum):
 
 @unique
 class AutoNumaStatus(Enum):
+    """
+    """
     DISABLE = 'disable'
     ENABLE = 'enable'
     UNKNOWN = 'unknown'
@@ -25370,6 +25814,8 @@ class AutoNumaStatus(Enum):
 
 @unique
 class AutoPinningPolicy(Enum):
+    """
+    """
     ADJUST = 'adjust'
     DISABLED = 'disabled'
     EXISTING = 'existing'
@@ -25383,6 +25829,8 @@ class AutoPinningPolicy(Enum):
 
 @unique
 class BackupPhase(Enum):
+    """
+    """
     FAILED = 'failed'
     FINALIZING = 'finalizing'
     INITIALIZING = 'initializing'
@@ -25399,6 +25847,8 @@ class BackupPhase(Enum):
 
 @unique
 class BiosType(Enum):
+    """
+    """
     CLUSTER_DEFAULT = 'cluster_default'
     I440FX_SEA_BIOS = 'i440fx_sea_bios'
     Q35_OVMF = 'q35_ovmf'
@@ -25414,6 +25864,8 @@ class BiosType(Enum):
 
 @unique
 class BootDevice(Enum):
+    """
+    """
     CDROM = 'cdrom'
     HD = 'hd'
     NETWORK = 'network'
@@ -25427,6 +25879,8 @@ class BootDevice(Enum):
 
 @unique
 class BootProtocol(Enum):
+    """
+    """
     AUTOCONF = 'autoconf'
     DHCP = 'dhcp'
     NONE = 'none'
@@ -25442,6 +25896,8 @@ class BootProtocol(Enum):
 
 @unique
 class CheckpointState(Enum):
+    """
+    """
     CREATED = 'created'
     INVALID = 'invalid'
 
@@ -25454,6 +25910,8 @@ class CheckpointState(Enum):
 
 @unique
 class CloudInitNetworkProtocol(Enum):
+    """
+    """
     ENI = 'eni'
     OPENSTACK_METADATA = 'openstack_metadata'
 
@@ -25466,6 +25924,8 @@ class CloudInitNetworkProtocol(Enum):
 
 @unique
 class ClusterUpgradeAction(Enum):
+    """
+    """
     FINISH = 'finish'
     START = 'start'
     UPDATE_PROGRESS = 'update_progress'
@@ -25479,6 +25939,8 @@ class ClusterUpgradeAction(Enum):
 
 @unique
 class ConfigurationType(Enum):
+    """
+    """
     OVA = 'ova'
     OVF = 'ovf'
 
@@ -25491,6 +25953,8 @@ class ConfigurationType(Enum):
 
 @unique
 class CpuMode(Enum):
+    """
+    """
     CUSTOM = 'custom'
     HOST_MODEL = 'host_model'
     HOST_PASSTHROUGH = 'host_passthrough'
@@ -25504,6 +25968,8 @@ class CpuMode(Enum):
 
 @unique
 class CpuPinningPolicy(Enum):
+    """
+    """
     DEDICATED = 'dedicated'
     ISOLATE_THREADS = 'isolate_threads'
     MANUAL = 'manual'
@@ -25519,6 +25985,8 @@ class CpuPinningPolicy(Enum):
 
 @unique
 class CreationStatus(Enum):
+    """
+    """
     COMPLETE = 'complete'
     FAILED = 'failed'
     IN_PROGRESS = 'in_progress'
@@ -25533,6 +26001,8 @@ class CreationStatus(Enum):
 
 @unique
 class DataCenterStatus(Enum):
+    """
+    """
     CONTEND = 'contend'
     MAINTENANCE = 'maintenance'
     NOT_OPERATIONAL = 'not_operational'
@@ -25549,6 +26019,8 @@ class DataCenterStatus(Enum):
 
 @unique
 class DiskBackup(Enum):
+    """
+    """
     INCREMENTAL = 'incremental'
     NONE = 'none'
 
@@ -25561,6 +26033,8 @@ class DiskBackup(Enum):
 
 @unique
 class DiskBackupMode(Enum):
+    """
+    """
     FULL = 'full'
     INCREMENTAL = 'incremental'
 
@@ -25573,6 +26047,8 @@ class DiskBackupMode(Enum):
 
 @unique
 class DiskContentType(Enum):
+    """
+    """
     BACKUP_SCRATCH = 'backup_scratch'
     DATA = 'data'
     HOSTED_ENGINE = 'hosted_engine'
@@ -25593,6 +26069,8 @@ class DiskContentType(Enum):
 
 @unique
 class DiskFormat(Enum):
+    """
+    """
     COW = 'cow'
     RAW = 'raw'
 
@@ -25605,6 +26083,8 @@ class DiskFormat(Enum):
 
 @unique
 class DiskInterface(Enum):
+    """
+    """
     IDE = 'ide'
     SATA = 'sata'
     SPAPR_VSCSI = 'spapr_vscsi'
@@ -25620,6 +26100,8 @@ class DiskInterface(Enum):
 
 @unique
 class DiskStatus(Enum):
+    """
+    """
     ILLEGAL = 'illegal'
     LOCKED = 'locked'
     OK = 'ok'
@@ -25633,6 +26115,8 @@ class DiskStatus(Enum):
 
 @unique
 class DiskStorageType(Enum):
+    """
+    """
     CINDER = 'cinder'
     IMAGE = 'image'
     LUN = 'lun'
@@ -25647,6 +26131,8 @@ class DiskStorageType(Enum):
 
 @unique
 class DiskType(Enum):
+    """
+    """
     DATA = 'data'
     SYSTEM = 'system'
 
@@ -25659,6 +26145,8 @@ class DiskType(Enum):
 
 @unique
 class DisplayType(Enum):
+    """
+    """
     SPICE = 'spice'
     VNC = 'vnc'
 
@@ -25671,6 +26159,8 @@ class DisplayType(Enum):
 
 @unique
 class EntityExternalStatus(Enum):
+    """
+    """
     ERROR = 'error'
     FAILURE = 'failure'
     INFO = 'info'
@@ -25686,6 +26176,8 @@ class EntityExternalStatus(Enum):
 
 @unique
 class ExternalStatus(Enum):
+    """
+    """
     ERROR = 'error'
     FAILURE = 'failure'
     INFO = 'info'
@@ -25701,6 +26193,8 @@ class ExternalStatus(Enum):
 
 @unique
 class ExternalSystemType(Enum):
+    """
+    """
     GLUSTER = 'gluster'
     VDSM = 'vdsm'
 
@@ -25713,6 +26207,8 @@ class ExternalSystemType(Enum):
 
 @unique
 class ExternalVmProviderType(Enum):
+    """
+    """
     KVM = 'kvm'
     VMWARE = 'vmware'
     XEN = 'xen'
@@ -25726,6 +26222,8 @@ class ExternalVmProviderType(Enum):
 
 @unique
 class FenceType(Enum):
+    """
+    """
     MANUAL = 'manual'
     RESTART = 'restart'
     START = 'start'
@@ -25741,6 +26239,8 @@ class FenceType(Enum):
 
 @unique
 class FipsMode(Enum):
+    """
+    """
     DISABLED = 'disabled'
     ENABLED = 'enabled'
     UNDEFINED = 'undefined'
@@ -25754,6 +26254,8 @@ class FipsMode(Enum):
 
 @unique
 class FirewallType(Enum):
+    """
+    """
     FIREWALLD = 'firewalld'
     IPTABLES = 'iptables'
 
@@ -25766,6 +26268,8 @@ class FirewallType(Enum):
 
 @unique
 class GlusterBrickStatus(Enum):
+    """
+    """
     DOWN = 'down'
     UNKNOWN = 'unknown'
     UP = 'up'
@@ -25779,6 +26283,8 @@ class GlusterBrickStatus(Enum):
 
 @unique
 class GlusterHookStatus(Enum):
+    """
+    """
     DISABLED = 'disabled'
     ENABLED = 'enabled'
     MISSING = 'missing'

--- a/lib/ovirtsdk4/writer.py
+++ b/lib/ovirtsdk4/writer.py
@@ -113,9 +113,11 @@ class Writer(object):
         """
         Registers a write method.
 
-        `typ`:: The type.
+        `typ` \n
+        The type.
 
-        `writer`:: The reference to the method that writes the XML
+        `writer` \n
+        The reference to the method that writes the XML
         object corresponding to the type.
         """
         cls._writers[typ] = writer
@@ -127,13 +129,16 @@ class Writer(object):
         the type. For example, if the type of the object is `Vm` then it
         will write the `vm` tag, with its contents.
 
-        `obj`:: The object to write.
+        `obj` \n
+        The object to write.
 
-        `target`:: The XML writer where the output will be written. If
+        `target` \n
+        The XML writer where the output will be written. If
         this parameter isn't given, or if the value is `None` the method
         will return a string containing the XML document.
 
-        `root`:: The name of the root tag of the generated XML document.
+        `root` \n
+        The name of the root tag of the generated XML document.
         This isn't needed when writing single objects, as the tag is
         calculated from the type of the object. For example, if the
         object isa virtual machine then the tag will be `vm`. But when
@@ -141,7 +146,8 @@ class Writer(object):
         be empty, or have different types of objects. In this case, for
         lists, if it isn't provided an exception will be raised.
 
-        `indent`:: Indicates if the output should be indented, for
+        `indent` \n
+        Indicates if the output should be indented, for
         easier reading by humans.
         """
         # If the target is `None` then create a temporary XML writer to

--- a/lib/ovirtsdk4/writers.py
+++ b/lib/ovirtsdk4/writers.py
@@ -23,6 +23,8 @@ from ovirtsdk4.writer import Writer
 
 
 class ActionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ActionWriter, self).__init__()
@@ -252,6 +254,8 @@ class ActionWriter(Writer):
 
 
 class AffinityGroupWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(AffinityGroupWriter, self).__init__()
@@ -313,6 +317,8 @@ class AffinityGroupWriter(Writer):
 
 
 class AffinityLabelWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(AffinityLabelWriter, self).__init__()
@@ -360,6 +366,8 @@ class AffinityLabelWriter(Writer):
 
 
 class AffinityRuleWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(AffinityRuleWriter, self).__init__()
@@ -397,6 +405,8 @@ class AffinityRuleWriter(Writer):
 
 
 class AgentWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(AgentWriter, self).__init__()
@@ -456,6 +466,8 @@ class AgentWriter(Writer):
 
 
 class AgentConfigurationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(AgentConfigurationWriter, self).__init__()
@@ -499,6 +511,8 @@ class AgentConfigurationWriter(Writer):
 
 
 class ApiWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ApiWriter, self).__init__()
@@ -542,6 +556,8 @@ class ApiWriter(Writer):
 
 
 class ApiSummaryWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ApiSummaryWriter, self).__init__()
@@ -581,6 +597,8 @@ class ApiSummaryWriter(Writer):
 
 
 class ApiSummaryItemWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ApiSummaryItemWriter, self).__init__()
@@ -616,6 +634,8 @@ class ApiSummaryItemWriter(Writer):
 
 
 class ApplicationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ApplicationWriter, self).__init__()
@@ -657,6 +677,8 @@ class ApplicationWriter(Writer):
 
 
 class AuthorizedKeyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(AuthorizedKeyWriter, self).__init__()
@@ -700,6 +722,8 @@ class AuthorizedKeyWriter(Writer):
 
 
 class BackupWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(BackupWriter, self).__init__()
@@ -757,6 +781,8 @@ class BackupWriter(Writer):
 
 
 class BalanceWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(BalanceWriter, self).__init__()
@@ -800,6 +826,8 @@ class BalanceWriter(Writer):
 
 
 class BiosWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(BiosWriter, self).__init__()
@@ -835,6 +863,8 @@ class BiosWriter(Writer):
 
 
 class BlockStatisticWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(BlockStatisticWriter, self).__init__()
@@ -868,6 +898,8 @@ class BlockStatisticWriter(Writer):
 
 
 class BondingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(BondingWriter, self).__init__()
@@ -907,6 +939,8 @@ class BondingWriter(Writer):
 
 
 class BookmarkWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(BookmarkWriter, self).__init__()
@@ -948,6 +982,8 @@ class BookmarkWriter(Writer):
 
 
 class BootWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(BootWriter, self).__init__()
@@ -985,6 +1021,8 @@ class BootWriter(Writer):
 
 
 class BootMenuWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(BootMenuWriter, self).__init__()
@@ -1018,6 +1056,8 @@ class BootMenuWriter(Writer):
 
 
 class BrickProfileDetailWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(BrickProfileDetailWriter, self).__init__()
@@ -1053,6 +1093,8 @@ class BrickProfileDetailWriter(Writer):
 
 
 class CdromWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CdromWriter, self).__init__()
@@ -1102,6 +1144,8 @@ class CdromWriter(Writer):
 
 
 class CertificateWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CertificateWriter, self).__init__()
@@ -1147,6 +1191,8 @@ class CertificateWriter(Writer):
 
 
 class CheckpointWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CheckpointWriter, self).__init__()
@@ -1196,6 +1242,8 @@ class CheckpointWriter(Writer):
 
 
 class CloudInitWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CloudInitWriter, self).__init__()
@@ -1241,6 +1289,8 @@ class CloudInitWriter(Writer):
 
 
 class ClusterWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ClusterWriter, self).__init__()
@@ -1374,6 +1424,8 @@ class ClusterWriter(Writer):
 
 
 class ClusterFeatureWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ClusterFeatureWriter, self).__init__()
@@ -1415,6 +1467,8 @@ class ClusterFeatureWriter(Writer):
 
 
 class ClusterLevelWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ClusterLevelWriter, self).__init__()
@@ -1460,6 +1514,8 @@ class ClusterLevelWriter(Writer):
 
 
 class ConfigurationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ConfigurationWriter, self).__init__()
@@ -1495,6 +1551,8 @@ class ConfigurationWriter(Writer):
 
 
 class ConsoleWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ConsoleWriter, self).__init__()
@@ -1528,6 +1586,8 @@ class ConsoleWriter(Writer):
 
 
 class CoreWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CoreWriter, self).__init__()
@@ -1563,6 +1623,8 @@ class CoreWriter(Writer):
 
 
 class CpuWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CpuWriter, self).__init__()
@@ -1612,6 +1674,8 @@ class CpuWriter(Writer):
 
 
 class CpuProfileWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CpuProfileWriter, self).__init__()
@@ -1657,6 +1721,8 @@ class CpuProfileWriter(Writer):
 
 
 class CpuTopologyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CpuTopologyWriter, self).__init__()
@@ -1694,6 +1760,8 @@ class CpuTopologyWriter(Writer):
 
 
 class CpuTuneWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CpuTuneWriter, self).__init__()
@@ -1727,6 +1795,8 @@ class CpuTuneWriter(Writer):
 
 
 class CpuTypeWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CpuTypeWriter, self).__init__()
@@ -1764,6 +1834,8 @@ class CpuTypeWriter(Writer):
 
 
 class CustomPropertyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(CustomPropertyWriter, self).__init__()
@@ -1801,6 +1873,8 @@ class CustomPropertyWriter(Writer):
 
 
 class DataCenterWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DataCenterWriter, self).__init__()
@@ -1868,6 +1942,8 @@ class DataCenterWriter(Writer):
 
 
 class DeviceWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DeviceWriter, self).__init__()
@@ -1915,6 +1991,8 @@ class DeviceWriter(Writer):
 
 
 class DiskWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DiskWriter, self).__init__()
@@ -2032,6 +2110,8 @@ class DiskWriter(Writer):
 
 
 class DiskAttachmentWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DiskAttachmentWriter, self).__init__()
@@ -2091,6 +2171,8 @@ class DiskAttachmentWriter(Writer):
 
 
 class DiskProfileWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DiskProfileWriter, self).__init__()
@@ -2136,6 +2218,8 @@ class DiskProfileWriter(Writer):
 
 
 class DiskSnapshotWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DiskSnapshotWriter, self).__init__()
@@ -2257,6 +2341,8 @@ class DiskSnapshotWriter(Writer):
 
 
 class DisplayWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DisplayWriter, self).__init__()
@@ -2318,6 +2404,8 @@ class DisplayWriter(Writer):
 
 
 class DnsWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DnsWriter, self).__init__()
@@ -2353,6 +2441,8 @@ class DnsWriter(Writer):
 
 
 class DnsResolverConfigurationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DnsResolverConfigurationWriter, self).__init__()
@@ -2390,6 +2480,8 @@ class DnsResolverConfigurationWriter(Writer):
 
 
 class DomainWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DomainWriter, self).__init__()
@@ -2435,6 +2527,8 @@ class DomainWriter(Writer):
 
 
 class DynamicCpuWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(DynamicCpuWriter, self).__init__()
@@ -2470,6 +2564,8 @@ class DynamicCpuWriter(Writer):
 
 
 class EntityProfileDetailWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(EntityProfileDetailWriter, self).__init__()
@@ -2503,6 +2599,8 @@ class EntityProfileDetailWriter(Writer):
 
 
 class ErrorHandlingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ErrorHandlingWriter, self).__init__()
@@ -2536,6 +2634,8 @@ class ErrorHandlingWriter(Writer):
 
 
 class EventWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(EventWriter, self).__init__()
@@ -2609,6 +2709,8 @@ class EventWriter(Writer):
 
 
 class EventSubscriptionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(EventSubscriptionWriter, self).__init__()
@@ -2656,6 +2758,8 @@ class EventSubscriptionWriter(Writer):
 
 
 class ExternalComputeResourceWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ExternalComputeResourceWriter, self).__init__()
@@ -2703,6 +2807,8 @@ class ExternalComputeResourceWriter(Writer):
 
 
 class ExternalDiscoveredHostWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ExternalDiscoveredHostWriter, self).__init__()
@@ -2752,6 +2858,8 @@ class ExternalDiscoveredHostWriter(Writer):
 
 
 class ExternalHostWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ExternalHostWriter, self).__init__()
@@ -2795,6 +2903,8 @@ class ExternalHostWriter(Writer):
 
 
 class ExternalHostGroupWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ExternalHostGroupWriter, self).__init__()
@@ -2844,6 +2954,8 @@ class ExternalHostGroupWriter(Writer):
 
 
 class ExternalHostProviderWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ExternalHostProviderWriter, self).__init__()
@@ -2905,6 +3017,8 @@ class ExternalHostProviderWriter(Writer):
 
 
 class ExternalNetworkProviderConfigurationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ExternalNetworkProviderConfigurationWriter, self).__init__()
@@ -2948,6 +3062,8 @@ class ExternalNetworkProviderConfigurationWriter(Writer):
 
 
 class ExternalProviderWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ExternalProviderWriter, self).__init__()
@@ -2999,6 +3115,8 @@ class ExternalProviderWriter(Writer):
 
 
 class ExternalTemplateImportWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ExternalTemplateImportWriter, self).__init__()
@@ -3046,6 +3164,8 @@ class ExternalTemplateImportWriter(Writer):
 
 
 class ExternalVmImportWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ExternalVmImportWriter, self).__init__()
@@ -3103,6 +3223,8 @@ class ExternalVmImportWriter(Writer):
 
 
 class FaultWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(FaultWriter, self).__init__()
@@ -3138,6 +3260,8 @@ class FaultWriter(Writer):
 
 
 class FencingPolicyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(FencingPolicyWriter, self).__init__()
@@ -3179,6 +3303,8 @@ class FencingPolicyWriter(Writer):
 
 
 class FileWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(FileWriter, self).__init__()
@@ -3224,6 +3350,8 @@ class FileWriter(Writer):
 
 
 class FilterWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(FilterWriter, self).__init__()
@@ -3267,6 +3395,8 @@ class FilterWriter(Writer):
 
 
 class FloppyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(FloppyWriter, self).__init__()
@@ -3316,6 +3446,8 @@ class FloppyWriter(Writer):
 
 
 class FopStatisticWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(FopStatisticWriter, self).__init__()
@@ -3351,6 +3483,8 @@ class FopStatisticWriter(Writer):
 
 
 class GlusterBrickWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GlusterBrickWriter, self).__init__()
@@ -3422,6 +3556,8 @@ class GlusterBrickWriter(Writer):
 
 
 class GlusterBrickAdvancedDetailsWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GlusterBrickAdvancedDetailsWriter, self).__init__()
@@ -3483,6 +3619,8 @@ class GlusterBrickAdvancedDetailsWriter(Writer):
 
 
 class GlusterBrickMemoryInfoWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GlusterBrickMemoryInfoWriter, self).__init__()
@@ -3516,6 +3654,8 @@ class GlusterBrickMemoryInfoWriter(Writer):
 
 
 class GlusterClientWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GlusterClientWriter, self).__init__()
@@ -3555,6 +3695,8 @@ class GlusterClientWriter(Writer):
 
 
 class GlusterHookWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GlusterHookWriter, self).__init__()
@@ -3614,6 +3756,8 @@ class GlusterHookWriter(Writer):
 
 
 class GlusterMemoryPoolWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GlusterMemoryPoolWriter, self).__init__()
@@ -3669,6 +3813,8 @@ class GlusterMemoryPoolWriter(Writer):
 
 
 class GlusterServerHookWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GlusterServerHookWriter, self).__init__()
@@ -3716,6 +3862,8 @@ class GlusterServerHookWriter(Writer):
 
 
 class GlusterVolumeWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GlusterVolumeWriter, self).__init__()
@@ -3781,6 +3929,8 @@ class GlusterVolumeWriter(Writer):
 
 
 class GlusterVolumeProfileDetailsWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GlusterVolumeProfileDetailsWriter, self).__init__()
@@ -3824,6 +3974,8 @@ class GlusterVolumeProfileDetailsWriter(Writer):
 
 
 class GracePeriodWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GracePeriodWriter, self).__init__()
@@ -3857,6 +4009,8 @@ class GracePeriodWriter(Writer):
 
 
 class GraphicsConsoleWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GraphicsConsoleWriter, self).__init__()
@@ -3910,6 +4064,8 @@ class GraphicsConsoleWriter(Writer):
 
 
 class GroupWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GroupWriter, self).__init__()
@@ -3961,6 +4117,8 @@ class GroupWriter(Writer):
 
 
 class GuestOperatingSystemWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(GuestOperatingSystemWriter, self).__init__()
@@ -4004,6 +4162,8 @@ class GuestOperatingSystemWriter(Writer):
 
 
 class HardwareInformationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HardwareInformationWriter, self).__init__()
@@ -4053,6 +4213,8 @@ class HardwareInformationWriter(Writer):
 
 
 class HighAvailabilityWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HighAvailabilityWriter, self).__init__()
@@ -4088,6 +4250,8 @@ class HighAvailabilityWriter(Writer):
 
 
 class HookWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HookWriter, self).__init__()
@@ -4133,6 +4297,8 @@ class HookWriter(Writer):
 
 
 class HostWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HostWriter, self).__init__()
@@ -4280,6 +4446,8 @@ class HostWriter(Writer):
 
 
 class HostCpuUnitWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HostCpuUnitWriter, self).__init__()
@@ -4329,6 +4497,8 @@ class HostCpuUnitWriter(Writer):
 
 
 class HostDeviceWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HostDeviceWriter, self).__init__()
@@ -4392,6 +4562,8 @@ class HostDeviceWriter(Writer):
 
 
 class HostDevicePassthroughWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HostDevicePassthroughWriter, self).__init__()
@@ -4425,6 +4597,8 @@ class HostDevicePassthroughWriter(Writer):
 
 
 class HostNicWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HostNicWriter, self).__init__()
@@ -4512,6 +4686,8 @@ class HostNicWriter(Writer):
 
 
 class HostNicVirtualFunctionsConfigurationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HostNicVirtualFunctionsConfigurationWriter, self).__init__()
@@ -4549,6 +4725,8 @@ class HostNicVirtualFunctionsConfigurationWriter(Writer):
 
 
 class HostStorageWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HostStorageWriter, self).__init__()
@@ -4626,6 +4804,8 @@ class HostStorageWriter(Writer):
 
 
 class HostedEngineWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(HostedEngineWriter, self).__init__()
@@ -4667,6 +4847,8 @@ class HostedEngineWriter(Writer):
 
 
 class IconWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(IconWriter, self).__init__()
@@ -4710,6 +4892,8 @@ class IconWriter(Writer):
 
 
 class IdentifiedWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(IdentifiedWriter, self).__init__()
@@ -4749,6 +4933,8 @@ class IdentifiedWriter(Writer):
 
 
 class ImageWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ImageWriter, self).__init__()
@@ -4794,6 +4980,8 @@ class ImageWriter(Writer):
 
 
 class ImageTransferWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ImageTransferWriter, self).__init__()
@@ -4863,6 +5051,8 @@ class ImageTransferWriter(Writer):
 
 
 class InitializationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(InitializationWriter, self).__init__()
@@ -4938,6 +5128,8 @@ class InitializationWriter(Writer):
 
 
 class InstanceTypeWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(InstanceTypeWriter, self).__init__()
@@ -5093,6 +5285,8 @@ class InstanceTypeWriter(Writer):
 
 
 class IoWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(IoWriter, self).__init__()
@@ -5126,6 +5320,8 @@ class IoWriter(Writer):
 
 
 class IpWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(IpWriter, self).__init__()
@@ -5165,6 +5361,8 @@ class IpWriter(Writer):
 
 
 class IpAddressAssignmentWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(IpAddressAssignmentWriter, self).__init__()
@@ -5200,6 +5398,8 @@ class IpAddressAssignmentWriter(Writer):
 
 
 class IscsiBondWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(IscsiBondWriter, self).__init__()
@@ -5245,6 +5445,8 @@ class IscsiBondWriter(Writer):
 
 
 class IscsiDetailsWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(IscsiDetailsWriter, self).__init__()
@@ -5310,6 +5512,8 @@ class IscsiDetailsWriter(Writer):
 
 
 class JobWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(JobWriter, self).__init__()
@@ -5365,6 +5569,8 @@ class JobWriter(Writer):
 
 
 class KatelloErratumWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(KatelloErratumWriter, self).__init__()
@@ -5422,6 +5628,8 @@ class KatelloErratumWriter(Writer):
 
 
 class KernelWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(KernelWriter, self).__init__()
@@ -5455,6 +5663,8 @@ class KernelWriter(Writer):
 
 
 class KsmWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(KsmWriter, self).__init__()
@@ -5490,6 +5700,8 @@ class KsmWriter(Writer):
 
 
 class LinkLayerDiscoveryProtocolElementWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(LinkLayerDiscoveryProtocolElementWriter, self).__init__()
@@ -5537,6 +5749,8 @@ class LinkLayerDiscoveryProtocolElementWriter(Writer):
 
 
 class LogicalUnitWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(LogicalUnitWriter, self).__init__()
@@ -5606,6 +5820,8 @@ class LogicalUnitWriter(Writer):
 
 
 class MDevTypeWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(MDevTypeWriter, self).__init__()
@@ -5645,6 +5861,8 @@ class MDevTypeWriter(Writer):
 
 
 class MacWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(MacWriter, self).__init__()
@@ -5678,6 +5896,8 @@ class MacWriter(Writer):
 
 
 class MacPoolWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(MacPoolWriter, self).__init__()
@@ -5725,6 +5945,8 @@ class MacPoolWriter(Writer):
 
 
 class MemoryOverCommitWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(MemoryOverCommitWriter, self).__init__()
@@ -5758,6 +5980,8 @@ class MemoryOverCommitWriter(Writer):
 
 
 class MemoryPolicyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(MemoryPolicyWriter, self).__init__()
@@ -5799,6 +6023,8 @@ class MemoryPolicyWriter(Writer):
 
 
 class MethodWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(MethodWriter, self).__init__()
@@ -5832,6 +6058,8 @@ class MethodWriter(Writer):
 
 
 class MigrationBandwidthWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(MigrationBandwidthWriter, self).__init__()
@@ -5867,6 +6095,8 @@ class MigrationBandwidthWriter(Writer):
 
 
 class MigrationOptionsWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(MigrationOptionsWriter, self).__init__()
@@ -5912,6 +6142,8 @@ class MigrationOptionsWriter(Writer):
 
 
 class MigrationPolicyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(MigrationPolicyWriter, self).__init__()
@@ -5951,6 +6183,8 @@ class MigrationPolicyWriter(Writer):
 
 
 class NetworkWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NetworkWriter, self).__init__()
@@ -6034,6 +6268,8 @@ class NetworkWriter(Writer):
 
 
 class NetworkAttachmentWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NetworkAttachmentWriter, self).__init__()
@@ -6091,6 +6327,8 @@ class NetworkAttachmentWriter(Writer):
 
 
 class NetworkConfigurationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NetworkConfigurationWriter, self).__init__()
@@ -6126,6 +6364,8 @@ class NetworkConfigurationWriter(Writer):
 
 
 class NetworkFilterWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NetworkFilterWriter, self).__init__()
@@ -6167,6 +6407,8 @@ class NetworkFilterWriter(Writer):
 
 
 class NetworkFilterParameterWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NetworkFilterParameterWriter, self).__init__()
@@ -6210,6 +6452,8 @@ class NetworkFilterParameterWriter(Writer):
 
 
 class NetworkLabelWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NetworkLabelWriter, self).__init__()
@@ -6253,6 +6497,8 @@ class NetworkLabelWriter(Writer):
 
 
 class NfsProfileDetailWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NfsProfileDetailWriter, self).__init__()
@@ -6288,6 +6534,8 @@ class NfsProfileDetailWriter(Writer):
 
 
 class NicWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NicWriter, self).__init__()
@@ -6367,6 +6615,8 @@ class NicWriter(Writer):
 
 
 class NicConfigurationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NicConfigurationWriter, self).__init__()
@@ -6410,6 +6660,8 @@ class NicConfigurationWriter(Writer):
 
 
 class NumaNodeWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NumaNodeWriter, self).__init__()
@@ -6461,6 +6713,8 @@ class NumaNodeWriter(Writer):
 
 
 class NumaNodePinWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(NumaNodePinWriter, self).__init__()
@@ -6498,6 +6752,8 @@ class NumaNodePinWriter(Writer):
 
 
 class OpenStackImageWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OpenStackImageWriter, self).__init__()
@@ -6539,6 +6795,8 @@ class OpenStackImageWriter(Writer):
 
 
 class OpenStackImageProviderWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OpenStackImageProviderWriter, self).__init__()
@@ -6596,6 +6854,8 @@ class OpenStackImageProviderWriter(Writer):
 
 
 class OpenStackNetworkWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OpenStackNetworkWriter, self).__init__()
@@ -6637,6 +6897,8 @@ class OpenStackNetworkWriter(Writer):
 
 
 class OpenStackNetworkProviderWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OpenStackNetworkProviderWriter, self).__init__()
@@ -6716,6 +6978,8 @@ class OpenStackNetworkProviderWriter(Writer):
 
 
 class OpenStackProviderWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OpenStackProviderWriter, self).__init__()
@@ -6769,6 +7033,8 @@ class OpenStackProviderWriter(Writer):
 
 
 class OpenStackSubnetWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OpenStackSubnetWriter, self).__init__()
@@ -6822,6 +7088,8 @@ class OpenStackSubnetWriter(Writer):
 
 
 class OpenStackVolumeProviderWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OpenStackVolumeProviderWriter, self).__init__()
@@ -6883,6 +7151,8 @@ class OpenStackVolumeProviderWriter(Writer):
 
 
 class OpenStackVolumeTypeWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OpenStackVolumeTypeWriter, self).__init__()
@@ -6926,6 +7196,8 @@ class OpenStackVolumeTypeWriter(Writer):
 
 
 class OpenstackVolumeAuthenticationKeyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OpenstackVolumeAuthenticationKeyWriter, self).__init__()
@@ -6975,6 +7247,8 @@ class OpenstackVolumeAuthenticationKeyWriter(Writer):
 
 
 class OperatingSystemWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OperatingSystemWriter, self).__init__()
@@ -7022,6 +7296,8 @@ class OperatingSystemWriter(Writer):
 
 
 class OperatingSystemInfoWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OperatingSystemInfoWriter, self).__init__()
@@ -7069,6 +7345,8 @@ class OperatingSystemInfoWriter(Writer):
 
 
 class OptionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(OptionWriter, self).__init__()
@@ -7106,6 +7384,8 @@ class OptionWriter(Writer):
 
 
 class PackageWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(PackageWriter, self).__init__()
@@ -7139,6 +7419,8 @@ class PackageWriter(Writer):
 
 
 class PayloadWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(PayloadWriter, self).__init__()
@@ -7176,6 +7458,8 @@ class PayloadWriter(Writer):
 
 
 class PermissionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(PermissionWriter, self).__init__()
@@ -7237,6 +7521,8 @@ class PermissionWriter(Writer):
 
 
 class PermitWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(PermitWriter, self).__init__()
@@ -7280,6 +7566,8 @@ class PermitWriter(Writer):
 
 
 class PmProxyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(PmProxyWriter, self).__init__()
@@ -7313,6 +7601,8 @@ class PmProxyWriter(Writer):
 
 
 class PortMirroringWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(PortMirroringWriter, self).__init__()
@@ -7344,6 +7634,8 @@ class PortMirroringWriter(Writer):
 
 
 class PowerManagementWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(PowerManagementWriter, self).__init__()
@@ -7397,6 +7689,8 @@ class PowerManagementWriter(Writer):
 
 
 class ProductWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ProductWriter, self).__init__()
@@ -7436,6 +7730,8 @@ class ProductWriter(Writer):
 
 
 class ProductInfoWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ProductInfoWriter, self).__init__()
@@ -7475,6 +7771,8 @@ class ProductInfoWriter(Writer):
 
 
 class ProfileDetailWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ProfileDetailWriter, self).__init__()
@@ -7516,6 +7814,8 @@ class ProfileDetailWriter(Writer):
 
 
 class PropertyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(PropertyWriter, self).__init__()
@@ -7551,6 +7851,8 @@ class PropertyWriter(Writer):
 
 
 class ProxyTicketWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ProxyTicketWriter, self).__init__()
@@ -7584,6 +7886,8 @@ class ProxyTicketWriter(Writer):
 
 
 class QosWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(QosWriter, self).__init__()
@@ -7659,6 +7963,8 @@ class QosWriter(Writer):
 
 
 class QuotaWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(QuotaWriter, self).__init__()
@@ -7720,6 +8026,8 @@ class QuotaWriter(Writer):
 
 
 class QuotaClusterLimitWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(QuotaClusterLimitWriter, self).__init__()
@@ -7771,6 +8079,8 @@ class QuotaClusterLimitWriter(Writer):
 
 
 class QuotaStorageLimitWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(QuotaStorageLimitWriter, self).__init__()
@@ -7818,6 +8128,8 @@ class QuotaStorageLimitWriter(Writer):
 
 
 class RangeWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RangeWriter, self).__init__()
@@ -7853,6 +8165,8 @@ class RangeWriter(Writer):
 
 
 class RateWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RateWriter, self).__init__()
@@ -7888,6 +8202,8 @@ class RateWriter(Writer):
 
 
 class RegistrationAffinityGroupMappingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RegistrationAffinityGroupMappingWriter, self).__init__()
@@ -7923,6 +8239,8 @@ class RegistrationAffinityGroupMappingWriter(Writer):
 
 
 class RegistrationAffinityLabelMappingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RegistrationAffinityLabelMappingWriter, self).__init__()
@@ -7958,6 +8276,8 @@ class RegistrationAffinityLabelMappingWriter(Writer):
 
 
 class RegistrationClusterMappingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RegistrationClusterMappingWriter, self).__init__()
@@ -7993,6 +8313,8 @@ class RegistrationClusterMappingWriter(Writer):
 
 
 class RegistrationConfigurationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RegistrationConfigurationWriter, self).__init__()
@@ -8038,6 +8360,8 @@ class RegistrationConfigurationWriter(Writer):
 
 
 class RegistrationDomainMappingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RegistrationDomainMappingWriter, self).__init__()
@@ -8073,6 +8397,8 @@ class RegistrationDomainMappingWriter(Writer):
 
 
 class RegistrationLunMappingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RegistrationLunMappingWriter, self).__init__()
@@ -8108,6 +8434,8 @@ class RegistrationLunMappingWriter(Writer):
 
 
 class RegistrationRoleMappingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RegistrationRoleMappingWriter, self).__init__()
@@ -8143,6 +8471,8 @@ class RegistrationRoleMappingWriter(Writer):
 
 
 class RegistrationVnicProfileMappingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RegistrationVnicProfileMappingWriter, self).__init__()
@@ -8178,6 +8508,8 @@ class RegistrationVnicProfileMappingWriter(Writer):
 
 
 class ReportedConfigurationWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ReportedConfigurationWriter, self).__init__()
@@ -8217,6 +8549,8 @@ class ReportedConfigurationWriter(Writer):
 
 
 class ReportedDeviceWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ReportedDeviceWriter, self).__init__()
@@ -8264,6 +8598,8 @@ class ReportedDeviceWriter(Writer):
 
 
 class RngDeviceWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RngDeviceWriter, self).__init__()
@@ -8299,6 +8635,8 @@ class RngDeviceWriter(Writer):
 
 
 class RoleWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(RoleWriter, self).__init__()
@@ -8346,6 +8684,8 @@ class RoleWriter(Writer):
 
 
 class SchedulingPolicyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SchedulingPolicyWriter, self).__init__()
@@ -8397,6 +8737,8 @@ class SchedulingPolicyWriter(Writer):
 
 
 class SchedulingPolicyUnitWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SchedulingPolicyUnitWriter, self).__init__()
@@ -8444,6 +8786,8 @@ class SchedulingPolicyUnitWriter(Writer):
 
 
 class SeLinuxWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SeLinuxWriter, self).__init__()
@@ -8477,6 +8821,8 @@ class SeLinuxWriter(Writer):
 
 
 class SerialNumberWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SerialNumberWriter, self).__init__()
@@ -8512,6 +8858,8 @@ class SerialNumberWriter(Writer):
 
 
 class SessionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SessionWriter, self).__init__()
@@ -8561,6 +8909,8 @@ class SessionWriter(Writer):
 
 
 class SkipIfConnectivityBrokenWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SkipIfConnectivityBrokenWriter, self).__init__()
@@ -8596,6 +8946,8 @@ class SkipIfConnectivityBrokenWriter(Writer):
 
 
 class SkipIfSdActiveWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SkipIfSdActiveWriter, self).__init__()
@@ -8629,6 +8981,8 @@ class SkipIfSdActiveWriter(Writer):
 
 
 class SnapshotWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SnapshotWriter, self).__init__()
@@ -8852,6 +9206,8 @@ class SnapshotWriter(Writer):
 
 
 class SpecialObjectsWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SpecialObjectsWriter, self).__init__()
@@ -8887,6 +9243,8 @@ class SpecialObjectsWriter(Writer):
 
 
 class SpmWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SpmWriter, self).__init__()
@@ -8922,6 +9280,8 @@ class SpmWriter(Writer):
 
 
 class SshWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SshWriter, self).__init__()
@@ -8971,6 +9331,8 @@ class SshWriter(Writer):
 
 
 class SshPublicKeyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SshPublicKeyWriter, self).__init__()
@@ -9014,6 +9376,8 @@ class SshPublicKeyWriter(Writer):
 
 
 class SsoWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SsoWriter, self).__init__()
@@ -9047,6 +9411,8 @@ class SsoWriter(Writer):
 
 
 class StatisticWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(StatisticWriter, self).__init__()
@@ -9112,6 +9478,8 @@ class StatisticWriter(Writer):
 
 
 class StepWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(StepWriter, self).__init__()
@@ -9175,6 +9543,8 @@ class StepWriter(Writer):
 
 
 class StorageConnectionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(StorageConnectionWriter, self).__init__()
@@ -9244,6 +9614,8 @@ class StorageConnectionWriter(Writer):
 
 
 class StorageConnectionExtensionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(StorageConnectionExtensionWriter, self).__init__()
@@ -9291,6 +9663,8 @@ class StorageConnectionExtensionWriter(Writer):
 
 
 class StorageDomainWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(StorageDomainWriter, self).__init__()
@@ -9390,6 +9764,8 @@ class StorageDomainWriter(Writer):
 
 
 class StorageDomainLeaseWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(StorageDomainLeaseWriter, self).__init__()
@@ -9423,6 +9799,8 @@ class StorageDomainLeaseWriter(Writer):
 
 
 class SystemOptionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SystemOptionWriter, self).__init__()
@@ -9464,6 +9842,8 @@ class SystemOptionWriter(Writer):
 
 
 class SystemOptionValueWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(SystemOptionValueWriter, self).__init__()
@@ -9499,6 +9879,8 @@ class SystemOptionValueWriter(Writer):
 
 
 class TagWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(TagWriter, self).__init__()
@@ -9550,6 +9932,8 @@ class TagWriter(Writer):
 
 
 class TemplateWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(TemplateWriter, self).__init__()
@@ -9705,6 +10089,8 @@ class TemplateWriter(Writer):
 
 
 class TemplateVersionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(TemplateVersionWriter, self).__init__()
@@ -9742,6 +10128,8 @@ class TemplateVersionWriter(Writer):
 
 
 class TicketWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(TicketWriter, self).__init__()
@@ -9777,6 +10165,8 @@ class TicketWriter(Writer):
 
 
 class TimeZoneWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(TimeZoneWriter, self).__init__()
@@ -9812,6 +10202,8 @@ class TimeZoneWriter(Writer):
 
 
 class TransparentHugePagesWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(TransparentHugePagesWriter, self).__init__()
@@ -9845,6 +10237,8 @@ class TransparentHugePagesWriter(Writer):
 
 
 class UnmanagedNetworkWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(UnmanagedNetworkWriter, self).__init__()
@@ -9888,6 +10282,8 @@ class UnmanagedNetworkWriter(Writer):
 
 
 class UsbWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(UsbWriter, self).__init__()
@@ -9923,6 +10319,8 @@ class UsbWriter(Writer):
 
 
 class UserWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(UserWriter, self).__init__()
@@ -9996,6 +10394,8 @@ class UserWriter(Writer):
 
 
 class UserOptionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(UserOptionWriter, self).__init__()
@@ -10039,6 +10439,8 @@ class UserOptionWriter(Writer):
 
 
 class ValueWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(ValueWriter, self).__init__()
@@ -10074,6 +10476,8 @@ class ValueWriter(Writer):
 
 
 class VcpuPinWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VcpuPinWriter, self).__init__()
@@ -10109,6 +10513,8 @@ class VcpuPinWriter(Writer):
 
 
 class VendorWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VendorWriter, self).__init__()
@@ -10148,6 +10554,8 @@ class VendorWriter(Writer):
 
 
 class VersionWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VersionWriter, self).__init__()
@@ -10197,6 +10605,8 @@ class VersionWriter(Writer):
 
 
 class VirtioScsiWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VirtioScsiWriter, self).__init__()
@@ -10230,6 +10640,8 @@ class VirtioScsiWriter(Writer):
 
 
 class VirtualNumaNodeWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VirtualNumaNodeWriter, self).__init__()
@@ -10287,6 +10699,8 @@ class VirtualNumaNodeWriter(Writer):
 
 
 class VlanWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VlanWriter, self).__init__()
@@ -10320,6 +10734,8 @@ class VlanWriter(Writer):
 
 
 class VmWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VmWriter, self).__init__()
@@ -10531,6 +10947,8 @@ class VmWriter(Writer):
 
 
 class VmBaseWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VmBaseWriter, self).__init__()
@@ -10664,6 +11082,8 @@ class VmBaseWriter(Writer):
 
 
 class VmMediatedDeviceWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VmMediatedDeviceWriter, self).__init__()
@@ -10713,6 +11133,8 @@ class VmMediatedDeviceWriter(Writer):
 
 
 class VmPlacementPolicyWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VmPlacementPolicyWriter, self).__init__()
@@ -10748,6 +11170,8 @@ class VmPlacementPolicyWriter(Writer):
 
 
 class VmPoolWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VmPoolWriter, self).__init__()
@@ -10819,6 +11243,8 @@ class VmPoolWriter(Writer):
 
 
 class VmSummaryWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VmSummaryWriter, self).__init__()
@@ -10856,6 +11282,8 @@ class VmSummaryWriter(Writer):
 
 
 class VnicPassThroughWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VnicPassThroughWriter, self).__init__()
@@ -10889,6 +11317,8 @@ class VnicPassThroughWriter(Writer):
 
 
 class VnicProfileWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VnicProfileWriter, self).__init__()
@@ -10946,6 +11376,8 @@ class VnicProfileWriter(Writer):
 
 
 class VnicProfileMappingWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VnicProfileMappingWriter, self).__init__()
@@ -10983,6 +11415,8 @@ class VnicProfileMappingWriter(Writer):
 
 
 class VolumeGroupWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(VolumeGroupWriter, self).__init__()
@@ -11020,6 +11454,8 @@ class VolumeGroupWriter(Writer):
 
 
 class WatchdogWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(WatchdogWriter, self).__init__()
@@ -11071,6 +11507,8 @@ class WatchdogWriter(Writer):
 
 
 class WeightWriter(Writer):
+    """
+    """
 
     def __init__(self):
         super(WeightWriter, self).__init__()

--- a/pdoc/custom.css
+++ b/pdoc/custom.css
@@ -1,0 +1,3 @@
+.decorator {
+    display: none;
+}


### PR DESCRIPTION
Documentation updated so that it builds properly with most recent pdoc version.

Alterations made:
- Links now work
- codeblocks updated
- full documentation now renders

Built version of the documentation that would be merged:
https://jasperb-teamblue.github.io/python-ovirt-engine-sdk4/ate/ovirtsdk4.html

Solves issue: https://github.com/oVirt/python-ovirt-engine-sdk4/issues/55