### PR TITLE
spec: add python3-setuptools to BuildRequires

### DIFF
--- a/python-ovirt-engine-sdk4.spec.in
+++ b/python-ovirt-engine-sdk4.spec.in
@@ -18,6 +18,7 @@ API.
 %package -n python3-ovirt-engine-sdk4
 Summary: oVirt Engine Software Development Kit (Python)
 BuildRequires: python3-devel
+BuildRequires: python3-setuptools
 Requires: libxml2
 Requires: python3
 Requires: python3-pycurl >= 7.43.0-6


### PR DESCRIPTION
On CentOS Stream 10 we need an explicit BR on
python3-setuptools as it's not installed by default.